### PR TITLE
Bumps version to fix hash mismatch in artifactory

### DIFF
--- a/hamilton/version.py
+++ b/hamilton/version.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 0, 1)


### PR DESCRIPTION
Getting a hash mismatch -- only way to fix is to bump the version