### PR TITLE
Add distributed execution via dask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # pycharm
 .idea/*
+
+# ignore dask execution files
+dask-worker-space/

--- a/hamilton/dask_executor.py
+++ b/hamilton/dask_executor.py
@@ -1,0 +1,24 @@
+import typing
+
+import pandas as pd
+
+from dask import compute
+from dask.delayed import Delayed, delayed
+
+from . import node
+
+
+class DaskExecutor:
+    def check_input_type(self, node: node.Node, input: typing.Any) -> bool:
+        # NOTE: the type of dask Delayed is unknown until they are computed
+        if isinstance(input, Delayed):
+            return True
+
+        return node.type == typing.Any or isinstance(input, node.type)
+
+    def execute(self, node: node.Node, kwargs: typing.Dict[str, typing.Any]) -> typing.Any:
+        return delayed(node.callable)(**kwargs)
+
+    def build_data_frame(self, columns: typing.Dict[str, typing.Any]) -> pd.DataFrame:
+        columns, = compute(columns)
+        return pd.DataFrame(columns)

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -10,6 +10,8 @@ import typing
 
 from dataclasses import dataclass
 
+from pandas.core.frame import DataFrame
+
 if __name__ == '__main__':
     import graph
     import node
@@ -76,7 +78,7 @@ class Driver(object):
         :return: a data frame consisting of the variables requested.
         """
         columns = self.raw_execute(final_vars, overrides, display_graph)
-        return pd.DataFrame(columns)
+        return self.executor.build_data_frame(columns)
 
     def raw_execute(self,
                     final_vars: List[str],
@@ -124,6 +126,9 @@ class DirectExecutor:
 
     def execute(self, node: node.Node, kwargs: typing.Dict[str, typing.Any]) -> typing.Any:
         return node.callable(**kwargs)
+
+    def build_data_frame(self, columns: typing.Dict[str, typing.Any]) -> pd.DataFrame:
+        return pd.DataFrame(columns)
 
 
 if __name__ == '__main__':

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -10,8 +10,6 @@ import typing
 
 from dataclasses import dataclass
 
-from pandas.core.frame import DataFrame
-
 if __name__ == '__main__':
     import graph
     import node

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -100,15 +100,20 @@ def create_function_graph(*modules: ModuleType, config: Dict[str, Any]) -> Dict[
 
 
 class FunctionGraph(object):
-    def __init__(self, *modules: ModuleType, config: Dict[str, Any]):
+    def __init__(self, *modules: ModuleType, config: Dict[str, Any], executor = None):
         """Initializes a function graph by crawling through modules. Function graph must have a config,
         as the config could determine the shape of the graph.
 
         :param modules: Modules to crawl for functions
         :param config:
         """
+        if executor is None:
+            from .driver import DirectExecutor
+            executor = DirectExecutor()
+
         self._config = config
         self.nodes = create_function_graph(*modules, config=self._config)
+        self.executor = executor
 
     @property
     def config(self):
@@ -204,6 +209,7 @@ class FunctionGraph(object):
     @staticmethod
     def execute_static(nodes: Collection[node.Node],
                        inputs: Dict[str, Any],
+                       executor,
                        computed: Dict[str, Any] = None,
                        overrides: Dict[str, Any] = None):
         """Executes computation on the given graph, inputs, and memoized computation.
@@ -246,7 +252,7 @@ class FunctionGraph(object):
                     if dependency.name in computed:
                         kwargs[dependency.name] = computed[dependency.name]
                 try:
-                    value = node.callable(**kwargs)
+                    value = executor.execute(node, kwargs)
                 except Exception as e:
                     logger.exception(f'Node {node.name} encountered an error')
                     raise
@@ -265,6 +271,7 @@ class FunctionGraph(object):
         return FunctionGraph.execute_static(
             nodes=nodes,
             inputs=self.config,
+            executor=self.executor,
             computed=computed,
-            overrides=overrides
+            overrides=overrides,
         )

--- a/tests/example_module.py
+++ b/tests/example_module.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+
+def avg_3wk_spend(spend: pd.Series) -> pd.Series:
+    """Rolling 3 week average spend."""
+    return spend.rolling(3).mean()
+
+
+def spend_per_signup(spend: pd.Series, signups: pd.Series) -> pd.Series:
+    """The cost per signup in relation to spend."""
+    return spend / signups

--- a/tests/test_dask_executor.py
+++ b/tests/test_dask_executor.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from hamilton.dask_executor import DaskExecutor
+import pytest
+
+from dask import compute
+from dask.delayed import delayed
+from distributed import Client
+
+from hamilton.driver import Driver
+
+from . import example_module
+
+
+@pytest.fixture
+def client():
+    with Client(set_as_default=False).as_current() as client:
+        yield client
+
+
+def test_dask_executor(client):
+    initial_columns = {
+        # NOTE: here you could load individual columns from a parquet file
+        # in delayed manner, e.g., using sth. along the lines of
+        #     delayed(lambda: pd.read_parquet(path, columns=[col])[col])()
+        'signups': delayed(lambda: pd.Series([1, 10, 50, 100, 200, 400]))(),
+        'spend': delayed(lambda: pd.Series([10, 10, 20, 40, 40, 50]))(),
+    }
+
+    dr = Driver(initial_columns, example_module, executor=DaskExecutor())
+
+    output_columns = [
+        'spend',
+        'signups',
+        'avg_3wk_spend',
+        'spend_per_signup',
+    ]
+    df = dr.execute(output_columns)
+
+    assert set(df) == set(output_columns)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,6 +5,7 @@ import pytest
 
 from hamilton import graph
 from hamilton import node
+from hamilton import driver
 import tests.resources.bad_functions
 import tests.resources.dummy_functions
 import tests.resources.parametrized_nodes
@@ -160,15 +161,16 @@ def create_testing_nodes():
 
 def test_execute():
     """Tests graph execution along with basic memoization since A is depended on by two functions."""
+    executor = driver.DirectExecutor()
     nodes = create_testing_nodes()
     inputs = {
         'b': 2,
         'c': 5
     }
     expected = {'A': 7, 'B': 49, 'C': 14, 'b': 2, 'c': 5}
-    actual = graph.FunctionGraph.execute_static(nodes.values(), inputs)
+    actual = graph.FunctionGraph.execute_static(nodes.values(), inputs, executor)
     assert actual == expected
-    actual = graph.FunctionGraph.execute_static(nodes.values(), inputs, overrides={'A': 8})
+    actual = graph.FunctionGraph.execute_static(nodes.values(), inputs, executor, overrides={'A': 8})
     assert actual['A'] == 8
 
 


### PR DESCRIPTION
Implements https://github.com/stitchfix/hamilton/issues/10

## Additions

- introduces an executor abstraction to allow customization of how nodes are executed
- implements an executor backed by dask

## Testing

1. Passes all existing tests
2. Adds a new tests for th dask executor

## Todos

- I did not include type hints for the executor, as I did not want to create a new module with a single class, but the executor also does not belong in the graph module, as it mixes driver and graph concens
- The cyclic import of driver in graph is not the bestest of styles - related to the question, where to put DirectExecutor
- I was a bit lazy with docs, etc. as I understand this PR is only meant as documentation. Happy to add them if there is a realistic chance for merging the changes

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Python

- [ ] python 3.6
- [ ] python 3.7
- [x] python 3.8