### PR TITLE
Make graphviz optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Requirements:
 To get started, first you need to install hamilton. It is published to pypi under `sf-hamilton`:
 > pip install sf-hamilton
 
+Note: to use the DAG visualization functionality, you should instead do:
+> pip install sf-hamilton[visualization]
+
 While it is installing we encourage you to start on the next section.
 
 Note: the content (i.e. names, function bodies) of our example code snippets are for illustrative purposes only, and don't reflect what we actually do internally.
@@ -92,14 +95,16 @@ output_columns = [
     'spend_per_signup',
 ]
 # let's create the dataframe!
-df = dr.execute(output_columns, display_graph=True)
+# if you only did `pip install sf-hamilton` earlier:
+df = dr.execute(output_columns)
+# else if you did `pip install sf-hamilton[visualization]` earlier:
+# df = dr.execute(output_columns, display_graph=True)
 print(df)
 ```
 3. Run my_script.py
 > python my_script.py
 
 You should see the following output:
-![hello_world_image](hello_world_image.png)
 
        spend  signups  avg_3wk_spend  spend_per_signup
     0     10        1            NaN            10.000
@@ -108,6 +113,10 @@ You should see the following output:
     3     40      100      23.333333             0.400
     4     40      200      33.333333             0.200
     5     50      400      43.333333             0.125
+
+You should see the following image if you set `display_graph=True`:
+
+![hello_world_image](hello_world_image.png)
 
 Congratulations - you just created your first dataframe with Hamilton!
 

--- a/examples/hello_world/my_script.py
+++ b/examples/hello_world/my_script.py
@@ -24,4 +24,5 @@ output_columns = [
 ]
 # let's create the dataframe!
 df = dr.execute(output_columns, display_graph=True)
+# do `pip install sf-hamilton[visualization]` if you want display_graph=True to work.
 print(df)

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -8,8 +8,6 @@ import logging
 from types import ModuleType
 from typing import Type, Dict, Any, Callable, Tuple, Set, Collection, List
 
-import networkx
-
 from hamilton import function_modifiers
 from hamilton import node
 from hamilton.node import NodeSource, DependencyType
@@ -145,6 +143,14 @@ class FunctionGraph(object):
             raise ModuleNotFoundError(
                 'graphviz is required for visualizing the function graph. Install it with:'
                 '\n\n  pip install graphviz'
+            )
+
+        try:
+            import networkx
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                'networkx is required for visualizing the function graph. Install it with:'
+                '\n\n  pip install networkx'
             )
 
         dot = graphviz.Digraph(comment='Dependency Graph')

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -8,7 +8,6 @@ import logging
 from types import ModuleType
 from typing import Type, Dict, Any, Callable, Tuple, Set, Collection, List
 
-import graphviz
 import networkx
 
 from hamilton import function_modifiers
@@ -140,6 +139,14 @@ class FunctionGraph(object):
         :param final_vars: the final vars we want -- else all if None.
         :param output_file_path: the path where we want to store the a `dot` file + pdf picture.
         """
+        try:
+            import graphviz
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                'graphviz is required for visualizing the function graph. Install it with:'
+                '\n\n  pip install graphviz'
+            )
+
         dot = graphviz.Digraph(comment='Dependency Graph')
 
         for n in nodes:

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -137,21 +137,23 @@ class FunctionGraph(object):
         :param final_vars: the final vars we want -- else all if None.
         :param output_file_path: the path where we want to store the a `dot` file + pdf picture.
         """
+        # Check to see if optional dependencies have been installed.
         try:
             import graphviz
         except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                'graphviz is required for visualizing the function graph. Install it with:'
-                '\n\n  pip install graphviz'
+            logger.exception(
+                ' graphviz is required for visualizing the function graph. Install it with:'
+                '\n\n  pip install sf-hamilton[visualization] or pip install graphviz \n\n'
             )
-
+            return
         try:
             import networkx
         except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                'networkx is required for visualizing the function graph. Install it with:'
-                '\n\n  pip install networkx'
+            logger.exception(
+                ' networkx is required for visualizing the function graph. Install it with:'
+                '\n\n  pip install sf-hamilton[visualization] or pip install networkx \n\n'
             )
+            return
 
         dot = graphviz.Digraph(comment='Dependency Graph')
 

--- a/hamilton/version.py
+++ b/hamilton/version.py
@@ -1,1 +1,1 @@
-VERSION = (1, 1, 1)
+VERSION = (1, 2, 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dataclasses
-graphviz
 networkx
 numpy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 dataclasses
-networkx
 numpy
 pandas

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,9 @@ setup(
     # default version installed with virtualenv. Make sure to update your tools!
     python_requires='>=3.6, <4',
 
+    # adding this to slim the package down, since these dependencies are only used to visualize the DAG.
+    extras_require={'visualization': ['graphviz', 'networkx']},
+
     # Relevant project URLs
     project_urls={  # Optional
         'Bug Reports': 'https://github.com/stitchfix/hamilton/issues',


### PR DESCRIPTION
Makes graphviz an optional dependency.

Fixes #26.



## Additions

- Helpful error message if graphviz isn't installed and the user tries to plot

## Removals

- Dependency on graphviz

## Testing

Not really sure how to test this. 

Surely there is a way to mock existence or non-existence of a package? Cursory googling did not reveal one.

## Todos

- Test maybe? If we can figure out how

## Checklist

I'm not sure I can do all of these things:

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [ ] python 3.6
- [ ] python 3.7
