### PR TITLE
Implements opinionated decorator lifecycle

### DIFF
--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -1,3 +1,4 @@
+import ast
 import functools
 import inspect
 from typing import Dict, Callable, Collection, Tuple, Union, Any, Type
@@ -7,6 +8,7 @@ import pandas as pd
 from hamilton import node
 from hamilton.function_modifiers_base import NodeCreator, NodeResolver, NodeExpander, NodeTransformer
 from hamilton.models import BaseModel
+from hamilton.node import DependencyType
 
 """
 Annotations for modifying the way functions get added to the DAG.
@@ -46,13 +48,8 @@ class parametrized(NodeExpander):
             raise InvalidDecoratorException(
                 f'Annotation is invalid -- no such parameter {self.parameter} in function {fn}')
 
-    def expand_node(self, node_: node.Node, config: Dict[str, Any]) -> Collection[node.Node]:
-        """For each parameter value, loop through, partially curry the function, and output a node.
-
-                :param config:
-                :param fn: Function to operate on.
-                :return: A collection of nodes, each of which is parametrized.
-                """
+    def expand_node(self, node_: node.Node, config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:
+        """For each parameter value, loop through, partially curry the function, and output a node."""
         input_types = node_.input_types
         nodes = []
         for (node_name, node_doc), value in self.assigned_output.items():
@@ -92,9 +89,8 @@ class parametrized_input(NodeExpander):
                     f'assigned_output key is incorrect: {node}. The parameterized decorator needs a dict of '
                     'input column -> [name, description] to function.')
 
-    def expand_node(self, node_: node.Node, config: Dict[str, Any]) -> Collection[node.Node]:
+    def expand_node(self, node_: node.Node, config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:
         nodes = []
-        fn = node_.callable
         input_types = node_.input_types
         for input_column, (node_name, node_description) in self.assigned_output.items():
             specific_inputs = {key: value for key, (value, _) in input_types.items()}
@@ -103,7 +99,7 @@ class parametrized_input(NodeExpander):
             def new_fn(*args, input_column=input_column, **kwargs):
                 kwargs = kwargs.copy()
                 kwargs[self.parameter] = kwargs.pop(input_column)
-                return fn(*args, **kwargs)
+                return node_.callable(*args, **kwargs)
 
             nodes.append(
                 node.Node(
@@ -155,15 +151,15 @@ class extract_columns(NodeExpander):
             raise InvalidDecoratorException(
                 f'For extracting columns, output type must be pandas dataframe, not: {output_type}')
 
-    def expand_node(self, node_: node.Node, config: Dict[str, Any]) -> Collection[node.Node]:
+    def expand_node(self, node_: node.Node, config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:
         """For each column to extract, output a node that extracts that column. Also, output the original dataframe
-                generator.
+        generator.
 
-                :param config:
-                :param fn: Function to extract columns from. Must output a dataframe.
-                :return: A collection of nodes --
-                        one for the original dataframe generator, and another for each column to extract.
-                """
+        :param config:
+        :param fn: Function to extract columns from. Must output a dataframe.
+        :return: A collection of nodes --
+                one for the original dataframe generator, and another for each column to extract.
+        """
         fn = node_.callable
         base_doc = node_.documentation
 
@@ -406,3 +402,66 @@ class config(NodeResolver):
             return all(configuration.get(key) not in value for key, value in key_value_group_pairs.items())
 
         return config(resolves)
+
+
+class augment(NodeTransformer):
+    def __init__(self, expr: str, output_type: Type[Type] = None):
+        """Takes in an expression to transform a node. Expression must be of the form: foo=...
+        Note that this is potentially unsafe!!! We use `eval` in this, so if you execute hamilton code with this
+        it could easily carry out extra code. Keep this in mind when you use @augment -- utilize at your own peril.
+
+        :param expr: expression to transform the node. Must have a variable in it with the function's name.
+        :param output_type: Type of the output, if it differs from the node. Make sure to specify this
+        if it differs or the types will not compile.
+        """
+        self.expr = expr
+        self.expression = expr
+        self.output_type = output_type
+
+    def transform_node(self, node_: node.Node, config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:
+        """Transforms a node using the expression.
+
+        :param node_: Node to transform
+        :param output_type: The type of the node output. If it changes, then we specify it as Any
+        :return: The collection of nodes that are outputted by this transform. Will be an extra node
+        with the expression applied to the result of the original node.
+        """
+
+        expression_parsed = ast.parse(self.expression, mode='eval')
+        dependent_variables = {item.id for item in ast.walk(expression_parsed) if isinstance(item, ast.Name)}
+
+        var_name = fn.__name__
+        # We should be passing the function through (or the name?)
+
+        def new_function(**kwargs):
+            kwargs_for_original_call = {key: value for key, value in kwargs.items() if key in node_.input_types}
+            unmodified_result = node_.callable(**kwargs_for_original_call)
+            kwargs_for_new_call = {key: value for key, value in kwargs.items() if key in dependent_variables}
+            kwargs_for_new_call[var_name] = unmodified_result
+            return eval(self.expression, kwargs_for_new_call)
+
+        replacement_node = node.Node(
+            name=node_.name,
+            typ=node_.type if self.output_type is None else self.output_type,
+            doc_string=node_.documentation,
+            callabl=new_function,
+            node_source=node_.node_source,
+            input_types={
+                **{dependent_var: (Any, DependencyType.REQUIRED) for dependent_var in dependent_variables if dependent_var != var_name},
+                **{param: (input_type, dependency_type) for param, (input_type, dependency_type) in node_.input_types.items()}
+            }
+        )
+        return [replacement_node]
+
+        # TODO -- find a cleaner way to to copy a node
+
+    def validate(self, fn: Callable):
+        """Validates the expression is of the right form"""
+        parsed_expression = ast.parse(self.expression, mode='eval')
+        if not isinstance(parsed_expression, ast.Expression): #
+            raise ValueError(f'Expression {self.expr} must be an expression.')
+        dependent_variables = {item.id for item in ast.walk(parsed_expression) if isinstance(item, ast.Name)}
+        if fn.__name__ not in dependent_variables:
+            raise ValueError(f'Expression must depend on the function its transforming. Did not find {fn.__name__} in your expression\'s AST'
+                             f'If you have a function called "foo", your expression must be a function of foo (as well as other variables).'
+                             f'If you want to replace the value of this function, write your function as you normally would (E.G. as a function of its parameters).')

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -1,4 +1,4 @@
-import ast
+import functools
 import functools
 import inspect
 from typing import Dict, Callable, Collection, Tuple, Union, Any, Type
@@ -6,9 +6,8 @@ from typing import Dict, Callable, Collection, Tuple, Union, Any, Type
 import pandas as pd
 
 from hamilton import node
-from hamilton.function_modifiers_base import NodeCreator, NodeResolver, NodeExpander, NodeTransformer, sanitize_function_name
+from hamilton.function_modifiers_base import NodeCreator, NodeResolver, NodeExpander, sanitize_function_name
 from hamilton.models import BaseModel
-from hamilton.node import DependencyType
 
 """
 Annotations for modifying the way functions get added to the DAG.
@@ -403,68 +402,3 @@ class config(NodeResolver):
             return all(configuration.get(key) not in value for key, value in key_value_group_pairs.items())
 
         return config(resolves)
-
-
-class augment(NodeTransformer):
-    def __init__(self, expr: str, output_type: Type[Type] = None):
-        """Takes in an expression to transform a node. Expression must be of the form: foo=...
-        Note that this is potentially unsafe!!! We use `eval` in this, so if you execute hamilton code with this
-        it could easily carry out extra code. Keep this in mind when you use @augment -- utilize at your own peril.
-
-        :param expr: expression to transform the node. Must have a variable in it with the function's name.
-        :param output_type: Type of the output, if it differs from the node. Make sure to specify this
-        if it differs or the types will not compile.
-        """
-        self.expr = expr
-        self.expression = expr
-        self.output_type = output_type
-
-    def transform_node(self, node_: node.Node, config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:
-        """Transforms a node using the expression.
-
-        :param node_: Node to transform
-        :param output_type: The type of the node output. If it changes, then we specify it as Any
-        :return: The collection of nodes that are outputted by this transform. Will be an extra node
-        with the expression applied to the result of the original node.
-        """
-
-        expression_parsed = ast.parse(self.expression, mode='eval')
-        dependent_variables = {item.id for item in ast.walk(expression_parsed) if isinstance(item, ast.Name)}
-
-        var_name = sanitize_function_name(fn.__name__)
-
-        # We should be passing the function through (or the name?)
-
-        def new_function(**kwargs):
-            kwargs_for_original_call = {key: value for key, value in kwargs.items() if key in node_.input_types}
-            unmodified_result = node_.callable(**kwargs_for_original_call)
-            kwargs_for_new_call = {key: value for key, value in kwargs.items() if key in dependent_variables}
-            kwargs_for_new_call[var_name] = unmodified_result
-            return eval(self.expression, kwargs_for_new_call)
-
-        replacement_node = node.Node(
-            name=node_.name,
-            typ=node_.type if self.output_type is None else self.output_type,
-            doc_string=node_.documentation,
-            callabl=new_function,
-            node_source=node_.node_source,
-            input_types={
-                **{dependent_var: (Any, DependencyType.REQUIRED) for dependent_var in dependent_variables if dependent_var != var_name},
-                **{param: (input_type, dependency_type) for param, (input_type, dependency_type) in node_.input_types.items()}
-            }
-        )
-        return [replacement_node]
-
-        # TODO -- find a cleaner way to to copy a node
-
-    def validate(self, fn: Callable):
-        """Validates the expression is of the right form"""
-        parsed_expression = ast.parse(self.expression, mode='eval')
-        if not isinstance(parsed_expression, ast.Expression):
-            raise ValueError(f'Expression {self.expr} must be an expression.')
-        dependent_variables = {item.id for item in ast.walk(parsed_expression) if isinstance(item, ast.Name)}
-        var_name = sanitize_function_name(fn.__name__)
-        if var_name not in dependent_variables:
-            raise ValueError(f'Expression must depend on the function its transforming. Did not find {var_name} in your expression\'s AST '
-                             f'If you have a function called "foo", your expression must be a function of foo (as well as other variables). '
-                             f'If you want to replace the value of this function, write your function as you normally would (E.G. as a function of its parameters).')

--- a/hamilton/function_modifiers_base.py
+++ b/hamilton/function_modifiers_base.py
@@ -67,7 +67,7 @@ class NodeTransformLifecycle(abc.ABC):
 
 
 class NodeResolver(NodeTransformLifecycle):
-    """Decorator to resolve a nodes function. Can modify anything about the function and is run before the node."""
+    """Decorator to resolve a nodes function. Can modify anything about the function and is run at DAG creation time."""
 
     @abc.abstractmethod
     def resolve(self, fn: Callable, configuration: Dict[str, Any]) -> Callable:
@@ -142,11 +142,13 @@ class SubDAGModifier(NodeTransformLifecycle, abc.ABC):
 
 
 class NodeExpander(SubDAGModifier):
+    """Expands a node into multiple nodes. This is a special case of the SubDAGModifier,
+    which allows modification of some portion of the DAG. This just modifies a single node."""
     EXPAND_NODES = 'expand_nodes'
 
     def transform_dag(self, nodes: Collection[node.Node], config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:
         if len(nodes) != 1:
-            raise ValueError(f'Cannot call NodeExpander on more than one node. This must be called first in the DAG. Called with {nodes}')
+            raise ValueError(f'Cannot call NodeExpander: {self.__class__} on more than one node. This must be called first in the DAG. Called with {nodes}')
         node_, = nodes
         return self.expand_node(node_, config, fn)
 

--- a/hamilton/function_modifiers_base.py
+++ b/hamilton/function_modifiers_base.py
@@ -58,7 +58,7 @@ class NodeTransformLifecycle(abc.ABC):
         lifecycle_name = self.__class__.get_lifecycle_name()
         if hasattr(fn, self.get_lifecycle_name()):
             if not self.allows_multiple():
-                raise ValueError(f"Got multiple decorators for decorator @{self.__class__}. Only one allowed.")
+                raise ValueError(f'Got multiple decorators for decorator @{self.__class__}. Only one allowed.')
             curr_value = getattr(fn, lifecycle_name)
             setattr(fn, lifecycle_name, curr_value + [self])
         else:

--- a/hamilton/function_modifiers_base.py
+++ b/hamilton/function_modifiers_base.py
@@ -1,0 +1,270 @@
+import abc
+from typing import Callable, Dict, Any, Collection, Tuple
+
+from hamilton import node
+
+
+class NodeTransformLifecycle(abc.ABC):
+    """Base class to represent the decorator lifecycle. Common among all node decorators."""
+
+    @classmethod
+    @abc.abstractmethod
+    def get_lifecycle_name(cls) -> str:
+        """Gives the lifecycle name of the node decorator. Unique to the class, will likely not be overwritten by subclasses.
+        Note that this is coupled with the resolve_node() function below.
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def allows_multiple(cls) -> bool:
+        """Whether or not multiple of these decorators are allowed.
+
+        :return: True if multiple decorators are allowed else False
+        """
+        pass
+
+    @abc.abstractmethod
+    def validate(self, fn: Callable):
+        """Validates the decorator against the function
+
+        :param fn: Function to validate against
+        :return: Nothing, raises exception if not valid.
+        """
+        pass
+
+    def __call__(self, fn: Callable):
+        """Calls the decorator by adding attributes using the get_lifecycle_name string.
+        These attributes are the pointer to the decorator object itself, and used later in resolve_nodes below.
+
+        :param fn: Function to decorate
+        :return: The function again, with the desired properties.
+        """
+        self.validate(fn)
+        lifecycle_name = self.__class__.get_lifecycle_name()
+        if hasattr(fn, self.get_lifecycle_name()):
+            if not self.allows_multiple():
+                raise ValueError(f"Got multiple decorators for decorator @{self.__class__}. Only one allowed.")
+            curr_value = getattr(fn, lifecycle_name)
+            setattr(fn, lifecycle_name, curr_value + [self])
+        else:
+            setattr(fn, lifecycle_name, [self])
+        return fn
+
+
+class NodeResolver(NodeTransformLifecycle):
+    """Decorator to resolve a nodes function. Can modify anything about the function and is run before the node."""
+
+    @abc.abstractmethod
+    def resolve(self, fn: Callable, configuration: Dict[str, Any]) -> Callable:
+        """Determines what a function resolves to. Returns None if it should not be included in the DAG.
+
+        :param fn: Function to resolve
+        :param configuration: DAG config
+        :return: A name if it should resolve to something. Otherwise None.
+        """
+        pass
+
+    @abc.abstractmethod
+    def validate(self, fn):
+        """Validates that the function can work with the function resolver.
+
+        :param fn: Function to validate
+        :return: nothing
+        :raises InvalidDecoratorException: if the function is not valid for this decorator
+        """
+        pass
+
+    @classmethod
+    def get_lifecycle_name(cls) -> str:
+        return 'resolve'
+
+    @classmethod
+    def allows_multiple(cls) -> bool:
+        return True
+
+
+class NodeCreator(abc.ABC):
+    """Abstract class for nodes that "expand" functions into other nodes."""
+
+    @abc.abstractmethod
+    def generate_node(self, fn: Callable, config: Dict[str, Any]) -> node.Node:
+        """Given a function, converts it to a series of nodes that it produces.
+
+        :param config:
+        :param fn: A function to convert.
+        :return: A collection of nodes.
+        """
+        pass
+
+    @abc.abstractmethod
+    def validate(self, fn: Callable):
+        """Validates that a function will work with this expander
+
+        :param fn: Function to validate.
+        :raises InvalidDecoratorException if this is not a valid function for the annotator
+        """
+        pass
+
+    @classmethod
+    def get_lifecycle_name(cls) -> str:
+        return 'generate'
+
+    @classmethod
+    def allows_multiple(cls) -> bool:
+        return False
+
+
+class SubDAGModifier(abc.ABC):
+    @abc.abstractmethod
+    def transform_dag(self, nodes: Collection[node.Node]) -> Collection[node.Node]:
+        """Modifies a DAG consisting of a set of nodes. Note that this is to support the following two base classes.
+
+        :param nodes: Collection of nodes (not necessarily connected) to modify
+        :return: the new DAG of nodes
+        """
+        pass
+
+
+class NodeExpander(SubDAGModifier, NodeTransformLifecycle):
+    EXPAND_NODES = 'expand_nodes'
+
+    def transform_dag(self, nodes: Collection[node.Node], config: Dict[str, Any]) -> Collection[node.Node]:
+        if len(nodes) != 1:
+            raise ValueError(f'Cannot call NodeExpander on more than one node. This must be called first in the DAG. Called with {nodes}')
+        node_, = nodes
+        return self.expand_node(node_, config)
+
+    @abc.abstractmethod
+    def expand_node(self, node_: node.Node, config: Dict[str, Any]) -> Collection[node.Node]:
+        """Given a single node, expands into multiple nodes. Note that this node list includes:
+        1. Each "output" node (think sink in a DAG)
+        2. All intermediate steps
+        So in essence, this forms a miniature DAG
+
+        :param node: The node to expand
+        :return: A collection of nodes to add to the DAG
+        """
+        pass
+
+    @abc.abstractmethod
+    def validate(self, fn: Callable):
+        pass
+
+    @classmethod
+    def get_lifecycle_name(cls) -> str:
+        return 'expand'
+
+    @classmethod
+    def allows_multiple(cls) -> bool:
+        return False
+
+
+class NodeTransformer(SubDAGModifier):
+    TRANSFORM_NODES = 'transform_nodes'
+
+    def _separate_final_nodes(self, nodes: Collection[node.Node]) -> Tuple[Collection[node.Node], Collection[node.Node]]:
+        """Separates out final nodes (sinks) from the nodes.
+
+        :param nodes: Nodes to separate out
+        :return: A list of nodes
+        """
+        all_dependencies = set(sum([[dep for dep in node_.dependencies] for node_ in nodes], []))
+        return [node_ for node_ in nodes if node_.name in all_dependencies], [node_ for node_ in nodes if node_.name not in all_dependencies]
+
+    def transform_dag(self, nodes: Collection[node.Node], config: Dict[str, Any]) -> Collection[node.Node]:
+        """Finds the sources and sinks and runs the transformer on each sink.
+        Then returns the result of the entire set of sinks. Note that each sink has to have a unique name.
+
+        :param nodes: subdag to modify
+        :return: The DAG of nodes in this node
+        """
+        internal_nodes, final_nodes = self._separate_final_nodes(nodes)
+        out = list(internal_nodes)
+        for sink in final_nodes:
+            out += list(self.transform_node(sink))
+        return out
+
+    @abc.abstractmethod
+    def transform_node(self, node_: node.Node) -> Collection[node.Node]:
+        pass
+
+    @abc.abstractmethod
+    def validate(self, fn: Callable):
+        pass
+
+    @classmethod
+    def get_lifecycle_name(cls) -> str:
+        return 'transform'
+
+    @classmethod
+    def allows_multiple(cls) -> bool:
+        return True
+
+
+class DefaultNodeCreator(NodeCreator):
+    def generate_node(self, fn: Callable, config: Dict[str, Any]) -> node.Node:
+        return node.Node.from_fn(fn)
+
+    def validate(self, fn: Callable):
+        pass
+
+
+class DefaultNodeResolver(NodeResolver):
+    def resolve(self, fn: Callable, configuration: Dict[str, Any]) -> Callable:
+        return fn
+
+    def validate(self, fn):
+        pass
+
+
+class DefaultNodeExpander(NodeExpander):
+    def expand_node(self, node_: node.Node, config: Dict[str, Any]) -> Collection[node.Node]:
+        return [node_]
+
+    def validate(self, fn: Callable):
+        pass
+
+
+def resolve_nodes(fn: Callable, config: Dict[str, Any]) -> Collection[node.Node]:
+    """Gets a list of nodes from a function. This is meant to be an abstraction between the node
+    and the function that it implements. This will end up coordinating with the decorators we build
+    to modify nodes.
+
+    Algorithm is as follows:
+    1. If there is a list of function resolvers, apply them one
+    after the other. Otherwise, apply the default function resolver
+    which will always return just the function. This determines whether to
+    proceed -- if any function resolver is none, short circuit and return
+    an empty list of nodes.
+
+    2. If there is a list of node creators, that list must be of length 1
+    -- this is determined in the node creator class. Apply that to get
+    the initial node.
+
+    3. If there is a list of node expanders, apply them. Otherwise apply the default
+    nodeexpander This must be a
+    list of length one. This gives out a list of nodes.
+
+    4. If there is a node transformer, apply that. Note that the node transformer
+    gets applied individually to just the sink nodes in the subdag. It subclasses
+    "DagTransformer" to do so.
+
+    5. Return the final list of nodes.
+
+    :param fn: Function to input.
+    :return: A list of nodes into which this function transforms.
+    """
+    node_resolvers = getattr(fn, NodeResolver.get_lifecycle_name(), [DefaultNodeResolver()])
+    for resolver in node_resolvers:
+        fn = resolver.resolve(fn, config)
+        if fn is None:
+            return []
+    node_creator, = getattr(fn, NodeCreator.get_lifecycle_name(), [DefaultNodeCreator()])
+    nodes = [node_creator.generate_node(fn, config)]
+    node_expander, = getattr(fn, NodeExpander.get_lifecycle_name(), [DefaultNodeExpander()])
+    nodes = node_expander.transform_dag(nodes, config)
+    node_transformers = getattr(fn, NodeTransformer.get_lifecycle_name(), [])
+    for dag_modifier in node_transformers:
+        nodes = dag_modifier.transform_dag(nodes, config)
+    return nodes

--- a/hamilton/function_modifiers_base.py
+++ b/hamilton/function_modifiers_base.py
@@ -4,10 +4,22 @@ from typing import Callable, Dict, Any, Collection, Tuple
 from hamilton import node
 
 
+def sanitize_function_name(name: str) -> str:
+    """Sanitizes the function name to use.
+    Note that this is a slightly leaky abstraction, but this is really just a single case in which we want to strip out
+    dunderscores. This will likely change over time, but for now we need a way for a decorator to know about the true
+    function name without having to rely on the decorator order. So, if you want the function name of the function you're
+    decorating, call this first.
+
+    :param name: Function name
+    :return: Sanitized version.
+    """
+    last_dunder_index = name.rfind('__')
+    return name[:last_dunder_index] if last_dunder_index != -1 else name
+
+
 class NodeTransformLifecycle(abc.ABC):
     """Base class to represent the decorator lifecycle. Common among all node decorators."""
-
-    fn = None # Will get modified when this decorator is called
 
     @classmethod
     @abc.abstractmethod

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -26,7 +26,7 @@ def is_submodule(child: ModuleType, parent: ModuleType):
 
 def custom_subclass_check(requested_type: Type[Type], param_type: Type[Type]):
     """This is a custom check as subclass does not work with python generic.
-    That said, its
+    We will likely need to revisit this in the future (perhaps integrate with graphadapter?)
 
     :param requested_type: Candidate subclass
     :param param_type: Type of parameter to check

--- a/hamilton/models.py
+++ b/hamilton/models.py
@@ -3,19 +3,15 @@ from typing import Any, List, Dict
 
 import pandas as pd
 
-"""Base classes for models in hamilton
-We define a model as anything whose inputs are configuration-driven.
-The goal of this is to allow users to write something like:
+class DynamicTransformBase(abc.ABC):
+    """Abstract class for a dynamic transform as seen by hamilton.
+    These are transforms that come from configuration parameters, and define the following:
+    1. The nodes that they depend on
+    2. What the transform does
 
-@model(...)
-def my_column():
-    #column that is some combinations of other columns using some previously trained model
-
-Note that the model-training is not yet in scope."""
-
-
-class BaseModel(abc.ABC):
-    """Abstract class for a model as seen by hamilton"""
+    Paired with the decorator @dynamic_transform(CLS, config_item, **extra_params) one can write incredibly powerful
+    DAGs that depend on dynamic configs.
+    """
 
     def __init__(self, config_parameters: Any, name: str):
         self._config_parameters = config_parameters
@@ -23,18 +19,16 @@ class BaseModel(abc.ABC):
 
     @abc.abstractmethod
     def get_dependents(self) -> List[str]:
-        """Gets the names/types of the inputs to this column.
-         :return: A list of columns on which this model depends.
+        """Gets the names/types of the inputs to this transform.
+        :return: A list of columns on which this model depends.
         """
         pass
 
     @abc.abstractmethod
-    def predict(self, **columns: pd.Series) -> pd.Series:
-        """Runs predictions based on a series of input values.
-        Should probably operate on one row at a time so we don't have to worry about lookback.
-        Alternatively, it could just output a scalar, E.G. the current cycle's value.
-         :param columns: Columns that are inputs to the model
-        :return: A series that is the results of the model's predictions
+    def compute(self, **inputs: Any) -> Any:
+        """Runs a computation based on a set of input values.
+        :param inputs: data that are inputs to the transform
+        :return: The result of the transform.
         """
         pass
 
@@ -46,3 +40,34 @@ class BaseModel(abc.ABC):
     @property
     def name(self) -> str:
         return self._name
+
+
+# Maintained for backwards compatibility
+# Will likely keep this in some way, but might change the name or the approach
+# with the 2.0 release
+class BaseModel(DynamicTransformBase, abc.ABC):
+    """Base classes for models in hamilton
+    We define a model as anything whose inputs are configuration-driven.
+    The goal of this is to allow users to write something like:
+
+    @model(...)
+    def my_column():
+        #column that is some combinations of other columns using some previously trained model
+
+    Note that the model-training is not yet in scope."""
+    def compute(self, **inputs: Any) -> Any:
+        """Delegates to predict function to compute this model's return.
+
+        :param inputs: Inputs for the model
+        :return: The result of claling the model.
+        """
+        return self.predict(**inputs)
+
+    @abc.abstractmethod
+    def predict(self, **inputs: pd.Series) -> pd.Series:
+        """Runs the predict() function on the model, given the set of kwargs.
+        :param inputs: Inputs to the model.
+        :return: A series representing the output of the model.
+        """
+
+        pass

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -2,7 +2,7 @@ import copy
 import inspect
 import logging
 from enum import Enum
-from typing import Type, Dict, Any, Callable, List
+from typing import Type, Dict, Any, Callable, List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class Node(object):
         return self._doc
 
     @property
-    def input_types(self) -> Dict[str, Type]:
+    def input_types(self) -> Dict[Any, Tuple[Any, DependencyType]]:
         return self._input_types
 
     @property

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -62,7 +62,13 @@ class Node(object):
 
         if self._node_source == NodeSource.STANDARD:
             if input_types is not None:
-                self._input_types = {key: (value, DependencyType.REQUIRED) for key, value in input_types.items()}
+                self._input_types = {}
+                for key, value in input_types.items():
+                    if isinstance(value, tuple):
+                        self._input_types[key] = value
+                    else:
+                        print(key, value)
+                        self._input_types = {key: (value, DependencyType.REQUIRED) for key, value in input_types.items()}
             else:
                 signature = inspect.signature(callabl)
                 self._input_types = {}

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -2,7 +2,7 @@ import copy
 import inspect
 import logging
 from enum import Enum
-from typing import Type, Dict, Any, Callable, List, Tuple
+from typing import Type, Dict, Any, Callable, List, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class Node(object):
                  doc_string: str = '',
                  callabl: Callable = None,
                  node_source: NodeSource = NodeSource.STANDARD,
-                 input_types: Dict[str, Type] = None):
+                 input_types: Dict[str, Union[Type, Tuple[Type, DependencyType]]] = None):
         """Constructor for our Node object.
 
         :param name: the name of the function.
@@ -67,7 +67,6 @@ class Node(object):
                     if isinstance(value, tuple):
                         self._input_types[key] = value
                     else:
-                        print(key, value)
                         self._input_types = {key: (value, DependencyType.REQUIRED) for key, value in input_types.items()}
             else:
                 signature = inspect.signature(callabl)

--- a/tests/experimental/decorators.py
+++ b/tests/experimental/decorators.py
@@ -1,0 +1,2 @@
+from hamilton import node
+from hamilton.experimental.decorators import augment

--- a/tests/resources/layered_decorators.py
+++ b/tests/resources/layered_decorators.py
@@ -5,11 +5,26 @@ def _sum(**kwargs: int) -> int:
     return sum(kwargs.values())
 
 
-@config.when(foo='bar')
 @does(_sum)
 @parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'First value'): 20})
 @augment("c**2+d")
-def c(a: int, b: int) -> int:
+@config.when(foo='bar')
+def c__foobar(a: int, b: int) -> int:
+    """Demonstrates utilizing a bunch of decorators.
+    In all, this outputs two total nodes.
+    - config.when makes it only apply when foo=bar
+    - @does makes it do the sum pattern
+    - @parametrized curries the function then turns it into two
+    - @augment changes the function to make each of those two final nodes take in vars c and d
+    """
+    pass
+
+
+@does(_sum)
+@parametrized(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'First value'): 22})
+@augment("c**2+d")
+@config.when(foo='baz')
+def c__foobaz(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.
     In all, this outputs two total nodes.
     - config.when makes it only apply when foo=bar

--- a/tests/resources/layered_decorators.py
+++ b/tests/resources/layered_decorators.py
@@ -1,32 +1,36 @@
 from hamilton.function_modifiers import config, does, parametrized
 
+"""Demonstrates a DAG with multiple decorators for functions.
+This is a good test case to ensure that all the decorators work together
+This DAG outputs two nodes -- e and f. The value of these will vary
+based on whether or not foo==bar or foo==baz in the config.
+"""
+
 def _sum(**kwargs: int) -> int:
     return sum(kwargs.values())
 
 
 @does(_sum)
-@parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'First value'): 20})
+@parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'Second value'): 20})
 @config.when(foo='bar')
 def c__foobar(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.
-    In all, this outputs two total nodes.
+    In all, this outputs two total nodes -- e and f (as its parametrized)
     - config.when makes it only apply when foo=bar
     - @does makes it do the sum pattern
     - @parametrized curries the function then turns it into two
-    - @augment changes the function to make each of those two final nodes take in vars c and d
     """
     pass
 
 
 @does(_sum)
-@parametrized(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'First value'): 22})
+@parametrized(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'Second value'): 22})
 @config.when(foo='baz')
 def c__foobaz(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.
-    In all, this outputs two total nodes.
+    In all, this outputs two total nodes -- e and f (as its parametrized)
     - config.when makes it only apply when foo=bar
     - @does makes it do the sum pattern
     - @parametrized curries the function then turns it into two
-    - @augment changes the function to make each of those two final nodes take in vars c and d
     """
     pass

--- a/tests/resources/layered_decorators.py
+++ b/tests/resources/layered_decorators.py
@@ -1,0 +1,20 @@
+from hamilton.function_modifiers import config, does, parametrized, augment
+
+
+def _sum(**kwargs: int) -> int:
+    return sum(kwargs.values())
+
+
+@config.when(foo='bar')
+@does(_sum)
+@parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'First value'): 20})
+@augment("c**2+d")
+def c(a: int, b: int) -> int:
+    """Demonstrates utilizing a bunch of decorators.
+    In all, this outputs two total nodes.
+    - config.when makes it only apply when foo=bar
+    - @does makes it do the sum pattern
+    - @parametrized curries the function then turns it into two
+    - @augment changes the function to make each of those two final nodes take in vars c and d
+    """
+    pass

--- a/tests/resources/layered_decorators.py
+++ b/tests/resources/layered_decorators.py
@@ -7,7 +7,7 @@ def _sum(**kwargs: int) -> int:
 
 @does(_sum)
 @parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'First value'): 20})
-@augment("c**2+d")
+@augment('c**2+d')
 @config.when(foo='bar')
 def c__foobar(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.
@@ -22,7 +22,7 @@ def c__foobar(a: int, b: int) -> int:
 
 @does(_sum)
 @parametrized(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'First value'): 22})
-@augment("c**2+d")
+@augment('c**2+d')
 @config.when(foo='baz')
 def c__foobaz(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.

--- a/tests/resources/layered_decorators.py
+++ b/tests/resources/layered_decorators.py
@@ -1,5 +1,4 @@
-from hamilton.function_modifiers import config, does, parametrized, augment
-
+from hamilton.function_modifiers import config, does, parametrized
 
 def _sum(**kwargs: int) -> int:
     return sum(kwargs.values())
@@ -7,7 +6,6 @@ def _sum(**kwargs: int) -> int:
 
 @does(_sum)
 @parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'First value'): 20})
-@augment('c**2+d')
 @config.when(foo='bar')
 def c__foobar(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.
@@ -22,7 +20,6 @@ def c__foobar(a: int, b: int) -> int:
 
 @does(_sum)
 @parametrized(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'First value'): 22})
-@augment('c**2+d')
 @config.when(foo='baz')
 def c__foobaz(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -3,7 +3,7 @@ from typing import Any, List, Dict
 import pandas as pd
 import pytest
 
-from hamilton import function_modifiers, models
+from hamilton import function_modifiers, models, function_modifiers_base
 from hamilton import node
 from hamilton.function_modifiers import does, ensure_function_empty
 from hamilton.node import DependencyType
@@ -294,9 +294,9 @@ def test_model_modifier():
         annotation.validate(bad_model)
 
 
-def test_filter_underscores():
-    assert function_modifiers.config._filter_underscores('fn_name__v2') == 'fn_name'
-    assert function_modifiers.config._filter_underscores('fn_name') == 'fn_name'
+def test_sanitize_function_name():
+    assert function_modifiers_base.sanitize_function_name('fn_name__v2') == 'fn_name'
+    assert function_modifiers_base.sanitize_function_name('fn_name') == 'fn_name'
 
 
 def test_config_modifier_validate():

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -368,22 +368,3 @@ def test_config_when_with_custom_name():
 
     annotation = function_modifiers.config.when(key='value', name='new_function_name')
     assert annotation.resolve(config_when_fn, {'key': 'value'}).__name__ == 'new_function_name'
-
-
-def test_augment_decorator():
-
-    def foo(a: int) -> int:
-        return a*2
-
-    annotation = function_modifiers.augment('foo*MULTIPLIER_foo+OFFSET_foo')
-    annotation.validate(foo)
-    nodes = annotation.transform_dag([node.Node.from_fn(foo)], {}, foo)
-    assert 1 == len(nodes)
-    nodes_by_name = {node_.name: node_ for node_ in nodes}
-    assert set(nodes_by_name) == {'foo'}
-    a = 5
-    MULTIPLIER_foo = 3
-    OFFSET_foo = 7
-    foo = a*2
-    foo = MULTIPLIER_foo*foo + OFFSET_foo
-    assert nodes_by_name['foo'].callable(a=a, MULTIPLIER_foo=MULTIPLIER_foo, OFFSET_foo=OFFSET_foo) == foo # note its foo_raw as that's the node on which it depends

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -375,7 +375,7 @@ def test_augment_decorator():
     def foo(a: int) -> int:
         return a*2
 
-    annotation = function_modifiers.augment("foo*MULTIPLIER_foo+OFFSET_foo")
+    annotation = function_modifiers.augment('foo*MULTIPLIER_foo+OFFSET_foo')
     annotation.validate(foo)
     nodes = annotation.transform_dag([node.Node.from_fn(foo)], {}, foo)
     assert 1 == len(nodes)
@@ -387,5 +387,3 @@ def test_augment_decorator():
     foo = a*2
     foo = MULTIPLIER_foo*foo + OFFSET_foo
     assert nodes_by_name['foo'].callable(a=a, MULTIPLIER_foo=MULTIPLIER_foo, OFFSET_foo=OFFSET_foo) == foo # note its foo_raw as that's the node on which it depends
-
-

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -298,4 +298,3 @@ def test_end_to_end_with_layered_decorators_resolves_false():
     fg = graph.FunctionGraph(tests.resources.layered_decorators, config=config)
     out = fg.execute([n for n in fg.get_nodes()], )
     assert {item: value for item, value in out.items() if item not in config} == {}
-

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -13,6 +13,7 @@ import tests.resources.parametrized_inputs
 import tests.resources.extract_column_nodes
 import tests.resources.config_modifier
 import tests.resources.typing_vs_not_typing
+import tests.resources.layered_decorators
 from hamilton.node import NodeSource
 
 
@@ -282,3 +283,19 @@ def test_config_can_override():
     fg = graph.FunctionGraph(tests.resources.config_modifier, config=config)
     out = fg.execute([n for n in fg.get_nodes()])
     assert out['new_param'] == 'new_value'
+
+
+def test_end_to_end_with_layered_decorators_resolves_true():
+    fg = graph.FunctionGraph(tests.resources.layered_decorators, config={'foo': 'bar', 'd': 10, 'b': 20})
+    out = fg.execute([n for n in fg.get_nodes()], overrides={'b': 10})
+    assert len(out) > 0  # test config.when resolves correctly
+    assert out['e'] == (20+10) ** 2 + 10
+    assert out['f'] == (30+10) ** 2 + 10
+
+
+def test_end_to_end_with_layered_decorators_resolves_false():
+    config = {'foo': 'not_bar', 'd': 10, 'b': 20}
+    fg = graph.FunctionGraph(tests.resources.layered_decorators, config=config)
+    out = fg.execute([n for n in fg.get_nodes()], )
+    assert {item: value for item, value in out.items() if item not in config} == {}
+

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -289,8 +289,8 @@ def test_end_to_end_with_layered_decorators_resolves_true():
     fg = graph.FunctionGraph(tests.resources.layered_decorators, config={'foo': 'bar', 'd': 10, 'b': 20})
     out = fg.execute([n for n in fg.get_nodes()], overrides={'b': 10})
     assert len(out) > 0  # test config.when resolves correctly
-    assert out['e'] == (20+10) ** 2 + 10
-    assert out['f'] == (30+10) ** 2 + 10
+    assert out['e'] == (20+10)
+    assert out['f'] == (30+10)
 
 
 def test_end_to_end_with_layered_decorators_resolves_false():


### PR DESCRIPTION
This adds to the set of decorators that can be applied to a node,
and puts them in a uniform setting. The ordering is provided in
function_base.resolve_nodes -- the algorithm is as follows:

1. If there is a list of function resolvers, apply them one
after the other. Otherwise, apply the default function resolver
which will always return just the function. This determines whether to
proceed -- if any function resolver is none, short circuit and return
an empty list of nodes.

2. If there is a list of node creators, that list must be of length 1
-- this is determined in the node creator class. Apply that to get
the initial node.

3. If there is a list of node expanders, apply that. This must be a
list of length one. This gives out a list of nodes.

4. If there is a node transformer, apply that. Note that the node transformer
gets applied individually to just the sink nodes in the subdag. It subclasses
"DagTransformer" to do so.

5. Return the final list of nodes.

## Additions

- Transformer node

## Removals

-

## Changes

- Refactors decorator lifecycle to be clearer/more flexible

## Testing

1.

## Screenshots
If applicable

## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [ ] python 3.6
- [ ] python 3.7
