### PR TITLE
Adds a SimplePythonGraphAdapter

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -137,3 +137,16 @@ class SimplePythonDataFrameGraphAdapter(HamiltonGraphAdapter, PandasDataFrameRes
 
     def execute_node(self, node: node.Node, kwargs: typing.Dict[str, typing.Any]) -> typing.Any:
         return node.callable(**kwargs)
+
+
+class SimplePythonGraphAdapter(SimplePythonDataFrameGraphAdapter):
+    """This class allows you to swap out the build_result very easily."""
+
+    def __init__(self, result_builder: ResultMixin):
+        self.result_builder = result_builder
+        if self.result_builder is None:
+            raise ValueError('You must provide a ResultMixin object for `result_builder`.')
+
+    def build_result(self, **columns: typing.Dict[str, typing.Any]) -> typing.Any:
+        """Delegates to the result builder function supplied."""
+        return self.result_builder.build_result(**columns)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import collections
+import typing
 
 import numpy as np
 from numpy import testing
@@ -30,3 +31,17 @@ def test_numpymatrixresult_raise_length_mismatch():
     )
     with pytest.raises(ValueError):
         base.NumpyMatrixResult().build_result(**columns)
+
+
+def test_SimplePythonGraphAdapter():
+    """Tests that it delegates as intended"""
+    class Foo(base.ResultMixin):
+        @staticmethod
+        def build_result(**columns: typing.Dict[str, typing.Any]) -> typing.Any:
+            columns.update({'esoteric': 'function'})
+            return columns
+    spga = base.SimplePythonGraphAdapter(Foo())
+    cols = {'a': 'b'}
+    expected = {'a': 'b', 'esoteric': 'function'}
+    actual = spga.build_result(**cols)
+    assert actual == expected


### PR DESCRIPTION
This allows you to easily insert a ResultMixin of your
choice if you just want regular python execution.

TODO: follow up with an example.

## Additions

- Adds SimplePythonGraphAdapter & unit test

## Removals

- N/A

## Changes

- N/A

## Testing

1. Added unit test

## Screenshots
N/A

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [x] python 3.6
- [x] python 3.7
