### PR TITLE
Changes the way drivers handle parameters

### DIFF
--- a/tests/resources/very_simple_dag.py
+++ b/tests/resources/very_simple_dag.py
@@ -1,0 +1,2 @@
+def b(a: int) -> int:
+    return a

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -298,3 +298,23 @@ def test_end_to_end_with_layered_decorators_resolves_false():
     fg = graph.FunctionGraph(tests.resources.layered_decorators, config=config)
     out = fg.execute([n for n in fg.get_nodes()], )
     assert {item: value for item, value in out.items() if item not in config} == {}
+
+
+def test_combine_inputs_no_collision():
+    """Tests the combine_and_validate_inputs functionality when there are no collisions"""
+    combined = graph.FunctionGraph.combine_config_and_inputs({'a': 1}, {'b': 2})
+    assert combined == {'a': 1, 'b': 2}
+
+
+def test_combine_inputs_collision():
+    """Tests the combine_and_validate_inputs functionality
+    when there are collisions of keys but not values"""
+    with pytest.raises(ValueError):
+        graph.FunctionGraph.combine_config_and_inputs({'a': 1}, {'a': 2})
+
+
+def test_combine_inputs_collision_2():
+    """Tests the combine_and_validate_inputs functionality
+    when there are collisions of keys and values"""
+    with pytest.raises(ValueError):
+        graph.FunctionGraph.combine_config_and_inputs({'a': 1}, {'a': 1})

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -1,7 +1,14 @@
 from hamilton.driver import Driver
+import tests.resources.very_simple_dag
 
 
 def test_driver_validate_input_types():
-    dr = Driver({'a': 1}, [])
+    dr = Driver({'a': 1})
     results = dr.raw_execute(['a'])
     assert results == {'a': 1}
+
+
+def test_driver_validate_runtime_input_types():
+    dr = Driver({}, tests.resources.very_simple_dag)
+    results = dr.raw_execute(['b'], inputs={'a': 1})
+    assert results == {'b': 1}


### PR DESCRIPTION
See https://github.com/stitchfix/hamilton/issues/52

Note: this is backwards compatible. The changes are that
we've added the "inputs" parameter to the driver, as well as the
function_graph executor. This allows external inputs to the DAG
at runtime, not just construction time.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots
If applicable

## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [ ] python 3.6
- [ ] python 3.7
