### PR TITLE
Adds integration test for h_spark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,37 @@ jobs:
           command: |
             . venv/bin/activate
             python -m pytest graph_adapter_tests/h_ray
+  spark-py38:
+    docker:
+      - image: cimg/openjdk:14.0   # need java on it
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+    steps:
+      - checkout
+      - run:
+          name: install hamilton dependencies + spark
+          command: |
+            # venv & pip weren't installed -- so have to do this hacky stuff
+            sudo apt-get update
+            sudo apt-get install aptitude
+            sudo aptitude install python3.8-venv -y
+            python3.8 -m venv venv
+            . venv/bin/activate
+            python3.8 --version
+            pip3.8 --version
+            pip3.8 install -r requirements-test.txt
+            pip3.8 install -r requirements.txt
+            pip3.8 install pyspark[pandas_on_spark]  # note bdist will error, but things install fine enough to run!
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python -m pytest graph_adapter_tests/h_spark
 workflows:
   version: 2
   unit-test-workflow:
@@ -171,3 +202,4 @@ workflows:
       - dask-py36
       - dask-py37
       - ray-py37
+      - spark-py38

--- a/graph_adapter_tests/h_spark/__init__.py
+++ b/graph_adapter_tests/h_spark/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Stefan Krawczyk <stefank@cs.stanford.edu>'

--- a/graph_adapter_tests/h_spark/resources
+++ b/graph_adapter_tests/h_spark/resources
@@ -1,0 +1,1 @@
+../../tests/resources

--- a/graph_adapter_tests/h_spark/test_h_spark.py
+++ b/graph_adapter_tests/h_spark/test_h_spark.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import pytest
+
+from pyspark.sql import SparkSession
+import pyspark.pandas as ps
+
+from hamilton import driver, base
+from hamilton.experimental import h_spark
+
+from .resources import example_module
+
+
+@pytest.fixture(scope='module')
+def spark_session():
+    spark = SparkSession.builder.getOrCreate()
+    yield spark
+    spark.stop()
+
+
+def test_koalas_spark_graph_adapter(spark_session):
+    initial_columns = {
+        'signups': ps.Series([1, 10, 50, 100, 200, 400], name='signups'),
+        'spend': ps.Series([10, 10, 20, 40, 40, 50], name='signups'),
+    }
+    ps.set_option('compute.ops_on_diff_frames', True)  # we should play around here on how to correctly initialize data.
+    ps.set_option('compute.default_index_type', 'distributed')  # this one doesn't seem to work?
+    dr = driver.Driver(
+        initial_columns, example_module,
+        adapter=h_spark.SparkKoalasGraphAdapter(
+            spark_session,
+            result_builder=base.PandasDataFrameResult(),
+            spine_column='spend')
+    )
+    output_columns = [
+        'spend',
+        'signups',
+        'avg_3wk_spend',
+        'spend_per_signup',
+    ]
+    df = dr.execute(output_columns)
+    assert set(df) == set(output_columns)
+    expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
+    pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
+    # TODO: do some more asserting?


### PR DESCRIPTION
This mirrors the h_dask and h_ray tests.

Adds this to run in circleci.

Note regarding circleci: since we need Java we
have to change the image. The image has python
but not pip. So I need to do some apt-get things,
and use aptitude to install things so that python
is in a working state on the image. It does complain
about bdist not installing with pyspark, however
that doesn't seem to break actually running the code.

[Short description explaining the high-level reason for the pull request]

## Additions

- integration test for h_spark.py graph adapter.

## Removals

- N/A

## Changes

- N/A

## Testing

1. Runs on circleci ✅

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [-] python 3.6  (wont' test)
- [x] python 3.7
- [x] python 3.8
