### PR TITLE
Stefan/refactor visualization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run:
           name: install hamilton dependencies
           command: |
+            sudo apt install graphviz
             python -m venv venv || virtualenv venv
             . venv/bin/activate
             python --version
@@ -50,6 +51,7 @@ jobs:
       - run:
           name: install hamilton dependencies
           command: |
+            sudo apt install graphviz
             python -m venv venv || virtualenv venv
             . venv/bin/activate
             python --version

--- a/examples/dask/hello_world/run.py
+++ b/examples/dask/hello_world/run.py
@@ -43,7 +43,9 @@ if __name__ == '__main__':
         'spend_per_signup',
         'spend_zero_mean_unit_variance'
     ]
-    df = dr.execute(output_columns, display_graph=False)
-    # will output test-output/execute.gv.pdf
+    df = dr.execute(output_columns)
+    # To visualize do `pip install sf-hamilton[visualization]` if you want these to work
+    # dr.visualize_execution(output_columns, './my_dag.dot', {})
+    # dr.display_all_functions('./my_full_dag.dot')
     logger.info(df.to_string())
     client.shutdown()

--- a/examples/hello_world/my_script.py
+++ b/examples/hello_world/my_script.py
@@ -25,6 +25,9 @@ output_columns = [
     'spend_zero_mean_unit_variance'
 ]
 # let's create the dataframe!
-df = dr.execute(output_columns, display_graph=False)
-# do `pip install sf-hamilton[visualization]` if you want display_graph=True to work.
+df = dr.execute(output_columns)
 print(df.to_string())
+
+# To visualize do `pip install sf-hamilton[visualization]` if you want these to work
+# dr.visualize_execution(output_columns, './my_dag.dot', {})
+# dr.display_all_functions('./my_full_dag.dot')

--- a/examples/ray/hello_world/run.py
+++ b/examples/ray/hello_world/run.py
@@ -37,6 +37,9 @@ if __name__ == '__main__':
         'spend_zero_mean_unit_variance'
     ]
     # let's create the dataframe!
-    df = dr.execute(output_columns, display_graph=False)
+    df = dr.execute(output_columns)
+    # To visualize do `pip install sf-hamilton[visualization]` if you want these to work
+    # dr.visualize_execution(output_columns, './my_dag.dot', {})
+    # dr.display_all_functions('./my_full_dag.dot')
     print(df.to_string())
     ray.shutdown()

--- a/examples/spark/hello_world/run.py
+++ b/examples/spark/hello_world/run.py
@@ -66,7 +66,10 @@ if __name__ == '__main__':
         'spend_zero_mean_unit_variance'
     ]
     # let's create the dataframe!
-    df = dr.execute(output_columns, display_graph=False)
+    df = dr.execute(output_columns)
+    # To visualize do `pip install sf-hamilton[visualization]` if you want these to work
+    # dr.visualize_execution(output_columns, './my_dag.dot', {})
+    # dr.display_all_functions('./my_full_dag.dot')
     print(type(df))
     print(df.to_string())
     spark.stop()

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -110,7 +110,9 @@ class Driver(object):
         """
         nodes, user_nodes = self.graph.get_required_functions(final_vars)
         self.validate_inputs(user_nodes, inputs)  # TODO -- validate within the function graph itself
-        if display_graph:
+        if display_graph:  # deprecated flow.
+            logger.warning('display_graph=True is deprecated. It will be removed in the 2.0.0 release. '
+                           'Please use visualize_execution().')
             self.visualize_execution(final_vars, 'test-output/execute.gv', {'view': True})
             if self.has_cycles(final_vars):  # here for backwards compatible driver behavior.
                 raise ValueError('Error: cycles detected in you graph.')
@@ -127,14 +129,16 @@ class Driver(object):
         """
         return [Variable(node.name, node.type) for node in self.graph.get_nodes()]
 
-    def display_all_functions(self, output_file_uri: str):
+    def display_all_functions(self, output_file_uri: str, render_kwargs: dict = None):
         """Displays the graph of all functions loaded!
 
         :param output_file_uri: the full URI of path + file name to save the dot file to.
             E.g. 'some/path/graph-all.dot'
+        :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
+            If you do not want to view the file, pass in `{'view':False}`.
         """
         try:
-            self.graph.display_all(output_file_uri)
+            self.graph.display_all(output_file_uri, render_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 
@@ -149,7 +153,8 @@ class Driver(object):
         :param final_vars: the outputs we want to compute.
         :param output_file_uri: the full URI of path + file name to save the dot file to.
             E.g. 'some/path/graph.dot'
-        :param render_kwargs: a dictionary of values we'll pass to graphviz render function.
+        :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
+            If you do not want to view the file, pass in `{'view':False}`.
         """
         nodes, user_nodes = self.graph.get_required_functions(final_vars)
         self.validate_inputs(user_nodes, self.graph.config)

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -129,29 +129,29 @@ class Driver(object):
         """
         return [Variable(node.name, node.type) for node in self.graph.get_nodes()]
 
-    def display_all_functions(self, output_file_uri: str, render_kwargs: dict = None):
+    def display_all_functions(self, output_file_path: str, render_kwargs: dict = None):
         """Displays the graph of all functions loaded!
 
-        :param output_file_uri: the full URI of path + file name to save the dot file to.
+        :param output_file_path: the full URI of path + file name to save the dot file to.
             E.g. 'some/path/graph-all.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
         """
         try:
-            self.graph.display_all(output_file_uri, render_kwargs)
+            self.graph.display_all(output_file_path, render_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 
     def visualize_execution(self,
                             final_vars: List[str],
-                            output_file_uri: str,
+                            output_file_path: str,
                             render_kwargs: dict):
         """Visualizes Execution.
 
         Note: overrides are not handled at this time.
 
         :param final_vars: the outputs we want to compute.
-        :param output_file_uri: the full URI of path + file name to save the dot file to.
+        :param output_file_path: the full URI of path + file name to save the dot file to.
             E.g. 'some/path/graph.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
@@ -159,7 +159,7 @@ class Driver(object):
         nodes, user_nodes = self.graph.get_required_functions(final_vars)
         self.validate_inputs(user_nodes, self.graph.config)
         try:
-            self.graph.display(nodes, user_nodes, output_file_uri, render_kwargs=render_kwargs)
+            self.graph.display(nodes, user_nodes, output_file_path, render_kwargs=render_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -190,10 +190,12 @@ class FunctionGraph(object):
     def get_nodes(self) -> List[node.Node]:
         return list(self.nodes.values())
 
-    def display_all(self, output_file_path: str = 'test-output/graph-all.gv'):
+    def display_all(self, output_file_path: str = 'test-output/graph-all.gv', render_kwargs: dict = None):
         """Displays & saves a dot file of the entire DAG structure constructed.
 
         :param output_file_path: the place to save the files.
+        :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
+            If you do not want to view the file, pass in `{'view':False}`.
         """
         defined_nodes = set()
         user_nodes = set()
@@ -202,7 +204,9 @@ class FunctionGraph(object):
                 user_nodes.add(n)
             else:
                 defined_nodes.add(n)
-        self.display(defined_nodes, user_nodes, output_file_path=output_file_path)
+        if render_kwargs is None:
+            render_kwargs = {}
+        self.display(defined_nodes, user_nodes, output_file_path=output_file_path, render_kwargs=render_kwargs)
 
     def has_cycles(self, nodes: Set[node.Node], user_nodes: Set[node.Node]) -> bool:
         """Checks that the graph created does not contain cycles.

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -218,12 +218,12 @@ class FunctionGraph(object):
         cycles = self.get_cycles(nodes, user_nodes)
         return True if cycles else False
 
-    def get_cycles(self, nodes: Set[node.Node], user_nodes: Set[node.Node]) -> List:
+    def get_cycles(self, nodes: Set[node.Node], user_nodes: Set[node.Node]) -> List[List[str]]:
         """Returns cycles found in the graph.
 
         :param nodes: the set of nodes that need to be computed.
         :param user_nodes: the set of inputs that the user provided.
-        :return: list of cycles
+        :return: list of cycles, which is a list of node names.
         """
         try:
             import networkx

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
+graphviz
+networkx
 pytest
 pytest-assume
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dataclasses
+dataclasses; python_version < '3.7'
 numpy
 pandas

--- a/tests/resources/cyclic_functions.py
+++ b/tests/resources/cyclic_functions.py
@@ -1,0 +1,23 @@
+"""
+Module for cyclic functions to test graph things with.
+"""
+# we import this to check we don't pull in this function when parsing this module.
+from tests.resources import only_import_me
+
+
+def A(b: int, c: int) -> int:
+    """Function that should become part of the graph - A"""
+    return b + c
+
+
+def B(A: int, D: int) -> int:
+    """Function that should become part of the graph - B"""
+    return A * A + D
+
+
+def C(B: int) -> int:  # empty string doc on purpose.
+    return B * 2
+
+
+def D(C: int) -> int:
+    return C + 1

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -321,6 +321,8 @@ def test_function_graph_display():
             user_nodes.add(n)
         else:
             defined_nodes.add(n)
+    # hack of a test -- but it works... sort the lines and match them up.
+    # why? because for some reason given the same graph, the output file isn't deterministic.
     expected = sorted(['// Dependency Graph\n',
                 'digraph {\n',
                 '\tA [label=A]\n',
@@ -346,6 +348,7 @@ def test_create_graphviz_graph():
     fg = graph.FunctionGraph(tests.resources.dummy_functions, config={})
     nodes, user_nodes = fg.get_required_functions(['A', 'B', 'C'])
     # hack of a test -- but it works... sort the lines and match them up.
+    # why? because for some reason given the same graph, the output file isn't deterministic.
     expected = sorted(['// test-graph',
                        'digraph {',
                        '\tB [label=B]',


### PR DESCRIPTION
Visualization was an afterthought we added quickly.
This change takes in feedback from https://github.com/stitchfix/hamilton/issues/45 and makes
it more amenable for actual use.

We therefore expose new functions, and deprecate
the `visualize` parameter  in `driver.execute()`.

The new functions enable the user to pass in a dictionary that will
be used as key word arguments (kwargs) to the
render function -- thereby giving lots of control on
how things are visualized. We also mirror the changes
in display_all_functions().

Along the way I also refactored the cycle detection
using networkx. This again, was a quick hack,
now it's a standalone implementation. We do break graph
 behavior, but not driver behavior with this refactor. I
believe that's fine, since we don't want people to
depend on FunctionGraph directly just yet.

Adds unit tests for these changes.

## Additions

- specific helper functions to create graphviz and networkx graphs.
- new functions to display and enable passing

## Removals

- N/A

## Changes

- Deprecates driver.execute display parameter
- changes display_all_functions in a backwards compatible manner.

## Testing

1. Locally
2. via unit tests


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [TODO link to standards]()
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python
Loosely tested across different python versions.
- [x] python 3.6
- [x] python 3.7
- [x] python 3.8
- [x] python 3.9
