### PR TITLE
Renames columns to outputs in driver & ResultMixin build_result function

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -23,7 +23,7 @@ class ResultMixin(object):
     """
     @staticmethod
     @abc.abstractmethod
-    def build_result(**columns: typing.Dict[str, typing.Any]) -> typing.Any:
+    def build_result(**outputs: typing.Dict[str, typing.Any]) -> typing.Any:
         """This function builds the result given the computed values."""
         pass
 
@@ -31,19 +31,19 @@ class ResultMixin(object):
 class DictResult(ResultMixin):
     """Simple function that returns the dict of column -> value results."""
     @staticmethod
-    def build_result(**columns: typing.Dict[str, typing.Any]) -> typing.Dict:
+    def build_result(**outputs: typing.Dict[str, typing.Any]) -> typing.Dict:
         """This function builds a simple dict of output -> computed values."""
-        return columns
+        return outputs
 
 
 class PandasDataFrameResult(ResultMixin):
     """Mixin for building a pandas dataframe from the result"""
 
     @staticmethod
-    def build_result(**columns: typing.Dict[str, typing.Any]) -> pd.DataFrame:
+    def build_result(**outputs: typing.Dict[str, typing.Any]) -> pd.DataFrame:
         # TODO check inputs are pd.Series, arrays, or scalars -- else error
         # TODO do a basic index check across pd.Series and flag where mismatches occur?
-        return pd.DataFrame(columns)
+        return pd.DataFrame(outputs)
 
 
 class NumpyMatrixResult(ResultMixin):
@@ -53,16 +53,16 @@ class NumpyMatrixResult(ResultMixin):
     """
 
     @staticmethod
-    def build_result(**columns: typing.Dict[str, typing.Any]) -> np.matrix:
+    def build_result(**outputs: typing.Dict[str, typing.Any]) -> np.matrix:
         """Builds a numpy matrix from the passed in, inputs.
 
-        :param columns: function_name -> np.array.
+        :param outputs: function_name -> np.array.
         :return: numpy matrix
         """
         # TODO check inputs are all numpy arrays/array like things -- else error
         num_rows = -1
         columns_with_lengths = collections.OrderedDict()
-        for col, val in columns.items():   # assumption is fixed order
+        for col, val in outputs.items():   # assumption is fixed order
             if isinstance(val, (int, float)):  # TODO add more things here
                 columns_with_lengths[(col, 1)] = val
             else:
@@ -154,6 +154,6 @@ class SimplePythonGraphAdapter(SimplePythonDataFrameGraphAdapter):
         if self.result_builder is None:
             raise ValueError('You must provide a ResultMixin object for `result_builder`.')
 
-    def build_result(self, **columns: typing.Dict[str, typing.Any]) -> typing.Any:
+    def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:
         """Delegates to the result builder function supplied."""
-        return self.result_builder.build_result(**columns)
+        return self.result_builder.build_result(**outputs)

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -89,8 +89,8 @@ class Driver(object):
         if display_graph:
             logger.warning('display_graph=True is deprecated. It will be removed in the 2.0.0 release. '
                            'Please use visualize_execution().')
-        columns = self.raw_execute(final_vars, overrides, display_graph, inputs=inputs)
-        return self.adapter.build_result(**columns)
+        outputs = self.raw_execute(final_vars, overrides, display_graph, inputs=inputs)
+        return self.adapter.build_result(**outputs)
 
     def raw_execute(self,
                     final_vars: List[str],
@@ -118,9 +118,9 @@ class Driver(object):
                 raise ValueError('Error: cycles detected in you graph.')
         memoized_computation = dict()  # memoized storage
         self.graph.execute(nodes, memoized_computation, overrides, inputs)
-        columns = {c: memoized_computation[c] for c in final_vars}  # only want request variables in df.
+        outputs = {c: memoized_computation[c] for c in final_vars}  # only want request variables in df.
         del memoized_computation  # trying to cleanup some memory
-        return columns
+        return outputs
 
     def list_available_variables(self) -> List[Variable]:
         """Returns available variables.

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -83,7 +83,7 @@ class Driver(object):
         :param final_vars: the final list of variables we want in the data frame.
         :param overrides: the user defined input variables.
         :param display_graph: DEPRECATED. Whether we want to display the graph being computed.
-        :param inputs: Runtime inputs to the DAG
+        :param inputs: Runtime inputs to the DAG.
         :return: a data frame consisting of the variables requested.
         """
         if display_graph:
@@ -145,7 +145,8 @@ class Driver(object):
     def visualize_execution(self,
                             final_vars: List[str],
                             output_file_path: str,
-                            render_kwargs: dict):
+                            render_kwargs: dict,
+                            inputs: Dict[str, Any] = None):
         """Visualizes Execution.
 
         Note: overrides are not handled at this time.
@@ -155,9 +156,10 @@ class Driver(object):
             E.g. 'some/path/graph.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
+        :param inputs: Optional. Runtime inputs to the DAG.
         """
         nodes, user_nodes = self.graph.get_required_functions(final_vars)
-        self.validate_inputs(user_nodes, self.graph.config)
+        self.validate_inputs(user_nodes, inputs)
         try:
             self.graph.display(nodes, user_nodes, output_file_path, render_kwargs=render_kwargs)
         except ImportError as e:

--- a/hamilton/experimental/h_dask.py
+++ b/hamilton/experimental/h_dask.py
@@ -96,16 +96,16 @@ class DaskGraphAdapter(base.HamiltonGraphAdapter):
         """
         return delayed(node.callable)(**kwargs)
 
-    def build_result(self, **columns: typing.Dict[str, typing.Any]) -> typing.Any:
+    def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:
         """Builds the result and brings it back to this running process.
 
-        :param columns: the dictionary of key -> Union[delayed object reference | value]
+        :param outputs: the dictionary of key -> Union[delayed object reference | value]
         :return: The type of object returned by self.result_builder.
         """
         if logger.isEnabledFor(logging.DEBUG):
-            for k, v in columns.items():
+            for k, v in outputs.items():
                 logger.info(f'Got column {k}, with type [{type(v)}].')
-        delayed_combine = delayed(self.result_builder.build_result)(**columns)
+        delayed_combine = delayed(self.result_builder.build_result)(**outputs)
         if self.visualize_kwargs is not None:
             delayed_combine.visualize(**self.visualize_kwargs)
         df, = compute(delayed_combine)

--- a/hamilton/experimental/h_ray.py
+++ b/hamilton/experimental/h_ray.py
@@ -59,16 +59,16 @@ class RayGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         """
         return ray.remote(node.callable).remote(**kwargs)
 
-    def build_result(self, **columns: typing.Dict[str, typing.Any]) -> typing.Any:
+    def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:
         """Builds the result and brings it back to this running process.
 
-        :param columns: the dictionary of key -> Union[ray object reference | value]
+        :param outputs: the dictionary of key -> Union[ray object reference | value]
         :return: The type of object returned by self.result_builder.
         """
         if logger.isEnabledFor(logging.DEBUG):
-            for k, v in columns.items():
+            for k, v in outputs.items():
                 logger.debug(f'Got column {k}, with type [{type(v)}].')
         # need to wrap our result builder in a remote call and then pass in what we want to build from.
-        remote_combine = ray.remote(self.result_builder.build_result).remote(**columns)
+        remote_combine = ray.remote(self.result_builder.build_result).remote(**outputs)
         result = ray.get(remote_combine)  # this materializes the object locally
         return result

--- a/hamilton/experimental/h_spark.py
+++ b/hamilton/experimental/h_spark.py
@@ -17,7 +17,7 @@ class KoalasDataFrameResult(base.ResultMixin):
     """Mixin for building a koalas dataframe from the result"""
 
     @staticmethod
-    def build_result(**columns: typing.Dict[str, typing.Any]) -> ps.DataFrame:
+    def build_result(**outputs: typing.Dict[str, typing.Any]) -> ps.DataFrame:
         """Right now this class is just used for signaling the return type."""
         pass
 
@@ -111,10 +111,10 @@ class SparkKoalasGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         """
         return node.callable(**kwargs)
 
-    def build_result(self, **columns: typing.Dict[str, typing.Any]) -> typing.Union[pd.DataFrame, ps.DataFrame]:
+    def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Union[pd.DataFrame, ps.DataFrame]:
         # we don't use the actual function for building right now, we use this hacky equivalent
-        df = ps.DataFrame(columns[self.spine_column])
-        for k, v in columns.items():
+        df = ps.DataFrame(outputs[self.spine_column])
+        for k, v in outputs.items():
             logger.info(f'Got column {k}, with type [{type(v)}].')
             df[k] = v
         if isinstance(self.result_builder, base.PandasDataFrameResult):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,7 +10,7 @@ from hamilton import base
 
 def test_numpymatrixresult_int():
     """Tests the happy path of build_result of numpymatrixresult"""
-    columns = collections.OrderedDict(
+    outputs = collections.OrderedDict(
         a=np.array([1, 7, 3, 7, 3, 6, 4, 9, 5, 0]),
         b=np.zeros(10),
         c=1
@@ -18,28 +18,28 @@ def test_numpymatrixresult_int():
     expected = np.array([[1, 7, 3, 7, 3, 6, 4, 9, 5, 0],
                          np.zeros(10),
                          np.ones(10)]).T
-    actual = base.NumpyMatrixResult().build_result(**columns)
+    actual = base.NumpyMatrixResult().build_result(**outputs)
     testing.assert_array_equal(actual, expected)
 
 
 def test_numpymatrixresult_raise_length_mismatch():
     """Test raising an error build_result of numpymatrixresult"""
-    columns = collections.OrderedDict(
+    outputs = collections.OrderedDict(
         a=np.array([1, 7, 3, 7, 3, 6, 4, 9, 5, 0]),
         b=np.array([1, 2, 3, 4, 5]),
         c=1
     )
     with pytest.raises(ValueError):
-        base.NumpyMatrixResult().build_result(**columns)
+        base.NumpyMatrixResult().build_result(**outputs)
 
 
 def test_SimplePythonGraphAdapter():
     """Tests that it delegates as intended"""
     class Foo(base.ResultMixin):
         @staticmethod
-        def build_result(**columns: typing.Dict[str, typing.Any]) -> typing.Any:
-            columns.update({'esoteric': 'function'})
-            return columns
+        def build_result(**outputs: typing.Dict[str, typing.Any]) -> typing.Any:
+            outputs.update({'esoteric': 'function'})
+            return outputs
     spga = base.SimplePythonGraphAdapter(Foo())
     cols = {'a': 'b'}
     expected = {'a': 'b', 'esoteric': 'function'}


### PR DESCRIPTION
The framework is generic, not only for tabular things. So removing
this language to not box people in.

## Changes

- changes use of `columns` to `outputs` in result mixin build_result().
- changes use of `columns` to `outputs` in driver code.

## Testing

1. Unit testing FTW.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [x] python 3.6
- [x] python 3.7
