### PR TITLE
remove unused imports

### DIFF
--- a/examples/model_examples/scikit-learn/my_train_evaluate_logic.py
+++ b/examples/model_examples/scikit-learn/my_train_evaluate_logic.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict
 
 import numpy as np
 from sklearn import base

--- a/examples/ray/hello_world/run.py
+++ b/examples/ray/hello_world/run.py
@@ -1,8 +1,6 @@
 import importlib
 import logging
-import sys
 
-import pandas as pd
 import ray
 
 from hamilton import base

--- a/examples/spark/hello_world/run.py
+++ b/examples/spark/hello_world/run.py
@@ -1,6 +1,5 @@
 import importlib
 import logging
-import sys
 
 import pyspark.pandas as ps
 from pyspark.sql import SparkSession

--- a/graph_adapter_tests/h_dask/test_h_dask.py
+++ b/graph_adapter_tests/h_dask/test_h_dask.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -1,4 +1,3 @@
-import copy
 import inspect
 import logging
 from enum import Enum


### PR DESCRIPTION
Thanks for this great project! I learned about Hamilton recently and was interested in contributing.

I noticed this project isn't currently using `flake8`, so I ran that over the code in this repo to look for opportunities to fix minor things.

This PR proposes removing a few unused imports found by running `flake8 .` from the root of the repo.

```text
./examples/model_examples/scikit-learn/my_train_evaluate_logic.py:1:1: F401 'typing.List' imported but unused
./examples/ray/hello_world/run.py:3:1: F401 'sys' imported but unused
./examples/ray/hello_world/run.py:5:1: F401 'pandas as pd' imported but unused
./examples/spark/hello_world/run.py:3:1: F401 'sys' imported but unused
./graph_adapter_tests/h_dask/test_h_dask.py:1:1: F401 'numpy as np' imported but unused
./hamilton/node.py:1:1: F401 'copy' imported but unused
```

## Additions

--

## Removals

Removes unused imports.

## Changes



## Testing

--

## Screenshots

--

## Notes

--

## Todos

--

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

--

### Python

- [ ] python 3.6
- [ ] python 3.7

### Notes for Reviewers

I tried to follow the PR template, but I don't understand what the "Python" section means.

Thanks very much for your time and consideration!