### PR TITLE
fix typos in docs and comments

### DIFF
--- a/decorators.md
+++ b/decorators.md
@@ -69,7 +69,7 @@ Note also that the different input variables must all have compatible types with
 ## @extract_columns
 This works on a function that outputs a dataframe, that we want to extract the columns from and make them individually
 available for consumption. So it expands a single function into _n functions_, each of which take in the output dataframe
- and output a specific column as named in the `extract_coumns` decorator.
+ and output a specific column as named in the `extract_columns` decorator.
 ```python
 import pandas as pd
 from hamilton.function_modifiers import extract_columns

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -168,7 +168,7 @@ class Driver(object):
     def has_cycles(self, final_vars: List[str]) -> bool:
         """Checks that the created graph does not have cycles.
 
-        :param final_vars: the outputs we want to comute.
+        :param final_vars: the outputs we want to compute.
         :return: boolean True for cycles, False for no cycles.
         """
         nodes, user_nodes = self.graph.get_required_functions(final_vars)

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -461,7 +461,7 @@ class config(NodeResolver):
     def when_in(name=None, **key_value_group_pairs: Collection[Any]) -> 'config':
         """Yields a decorator that resolves the function if all of the keys are equal to one of items in the list of values.
 
-        :param key_value_group_pairs: pairs of key-value mappings where the value is a lsit of possible values
+        :param key_value_group_pairs: pairs of key-value mappings where the value is a list of possible values
         :return: a configuration decorator
         """
 
@@ -474,7 +474,7 @@ class config(NodeResolver):
     def when_not_in(**key_value_group_pairs: Collection[Any]) -> 'config':
         """Yields a decorator that resolves the function only if none of the keys are in the list of values.
 
-        :param key_value_group_pairs: pairs of key-value mappings where the value is a lsit of possible values
+        :param key_value_group_pairs: pairs of key-value mappings where the value is a list of possible values
         :return: a configuration decorator
 
         :Example:

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -387,7 +387,7 @@ class FunctionGraph(object):
                 overrides: Dict[str, Any] = None,
                 inputs: Dict[str, Any] = None
                 ) -> Dict[str, Any]:
-        """Executes the DAG, given potential inputs/previously compoted components.
+        """Executes the DAG, given potential inputs/previously computed components.
 
         :param nodes: Nodes to compute
         :param computed: Nodes that have already been computed

--- a/hamilton/models.py
+++ b/hamilton/models.py
@@ -59,7 +59,7 @@ class BaseModel(DynamicTransformBase, abc.ABC):
         """Delegates to predict function to compute this model's return.
 
         :param inputs: Inputs for the model
-        :return: The result of claling the model.
+        :return: The result of calling the model.
         """
         return self.predict(**inputs)
 

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -19,7 +19,7 @@ class NodeSource(Enum):
     """
     STANDARD = 1  # standard dependencies
     EXTERNAL = 2  # This node's value should be taken from cache
-    PRIOR_RUN = 3  # This node's value sould be taken from a prior run.
+    PRIOR_RUN = 3  # This node's value should be taken from a prior run.
     # This is not used in a standard function graph, but it comes in handy for repeatedly running the same one.
 
 


### PR DESCRIPTION
I've been trying to get more familiar with `hamilton`, and looking for small ways to contribute as I do. Tonight, I tried searching for typos using `aspell` and found a few. This PR proposes fixing them.

## Additions

N/A

## Removals

N/A

## Changes

- fixes miscellaneous typos

## Testing

N/A

## Screenshots

N/A

## Notes

N/A

## Todos

N/A

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [x] python 3.6
- [x] python 3.7
