### PR TITLE
remove dependency on pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,6 @@ def load_test_requirements():
         return [line.strip() for line in f]
 
 
-setup_requirements = [
-    'pytest-runner',
-]
-
 test_requirements = load_test_requirements()
 
 setup(
@@ -78,11 +74,6 @@ setup(
     # similar to setup_requires, these packages are not added to your venv but are made available
     # during testing
     tests_require=test_requirements,
-
-    # Any packages required when running `python setup.py X` (where X is an alias). These packages
-    # are NOT installed as part of the virtualenv (thus not polluting your venv) but instead just
-    # made available to the setup.
-    setup_requires=setup_requirements,
 
     # Note that this feature requires pep8 >= v9 and a version of setup tools greater than the
     # default version installed with virtualenv. Make sure to update your tools!


### PR DESCRIPTION
Proposes removing the `setup`-time dependency on `pytest-runner` and `setuptools` keyword `setup_requires`, both of which are deprecated and (I think) not used by this project.

This project's CI always uses `python -m pytest`, not `python setup.py test`, so I don't think this dependencies and `setuptools.setup()` argument are necessary.

See "Notes" below for more details.

## Additions

N/A

## Removals

- removes `setup_requires` in `setup.py`, and list of dependencies passed to it

## Changes

- N/A

## Testing

Ran the following to emulate CircleCI locally.

```shell
docker run \
   --rm \
    -v $(pwd):/usr/local/src \
    --workdir /usr/local/src \
   -it circleci/python:3.7 \
        /bin/bash
```

And then installed `hamilton` and ran its tests.

```shell
# install dependencies
sudo apt install graphviz
python -m venv venv || virtualenv venv
. venv/bin/activate
python --version
pip --version
pip install -r requirements-test.txt
pip install -r requirements.txt
pip install "dask[complete]"

# run tests
python -m pytest --cov=hamilton tests/
python -m pytest graph_adapter_tests/h_dask
```

## Screenshots

N/A

## Notes

From https://pypi.org/project/pytest-runner/#description

> **Deprecation Notice**
> `pytest-runner` depends on deprecated features of `setuptools` and relies on features that break security mechanisms in pip. For example `setup_requires` and `tests_require` bypass `pip --require-hashes`. See also [pypa/setuptools#1684](https://github.com/pypa/setuptools/issues/1684).

> It is recommended that you:
> * Remove 'pytest-runner' from your `setup_requires`, preferably removing the `setup_requires` option.
> * Remove 'pytest' and any other testing requirements from `tests_require`, preferably removing the `tests_requires` option.

## Todos

N/A

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [ ] python 3.6
- [x] python 3.7
