### PR TITLE
remove support for 'python setup.py test'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,6 @@ def load_requirements():
     return list(requirements)
 
 
-def load_test_requirements():
-    with open('requirements-test.txt') as f:
-        return [line.strip() for line in f]
-
-
-test_requirements = load_test_requirements()
-
 setup(
     name='sf-hamilton',  # there's already a hamilton in pypi
     version=VERSION,
@@ -70,10 +63,6 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     test_suite='tests',
-
-    # similar to setup_requires, these packages are not added to your venv but are made available
-    # during testing
-    tests_require=test_requirements,
 
     # Note that this feature requires pep8 >= v9 and a version of setup tools greater than the
     # default version installed with virtualenv. Make sure to update your tools!


### PR DESCRIPTION
Follow-up to #81. This PR proposes removing `setup.py` metadata that is only required to run `python setup.py test`.

This project's CI doesn't use that command, and `setuptools` maintainers consider that command deprecated.

## Additions

None

## Removals

- removes `tests_require` from `setup.py`
- removes code used to read `requirements-test.txt` into `setup.py`

## Changes

- Just removals

## Testing

Ran the following to emulate CircleCI locally.

```shell
docker run \
   --rm \
    -v $(pwd):/usr/local/src \
    --workdir /usr/local/src \
   -it circleci/python:3.7 \
        /bin/bash
```

And then installed `hamilton` and ran its tests.

```shell
# install dependencies
sudo apt install graphviz
python -m venv venv || virtualenv venv
. venv/bin/activate
python --version
pip --version
pip install -r requirements-test.txt
pip install -r requirements.txt
pip install "dask[complete]"

# run tests
python -m pytest --cov=hamilton tests/
python -m pytest graph_adapter_tests/h_dask
```

## Screenshots

None

## Notes

From https://pypi.org/project/pytest-runner/#description

> **Deprecation Notice**
> `pytest-runner` depends on deprecated features of `setuptools` and relies on features that break security mechanisms in pip. For example `setup_requires` and `tests_require` bypass `pip --require-hashes`. See also [pypa/setuptools#1684](https://github.com/pypa/setuptools/issues/1684).

> It is recommended that you:
> * Remove 'pytest-runner' from your `setup_requires`, preferably removing the `setup_requires` option.
> * Remove 'pytest' and any other testing requirements from `tests_require`, preferably removing the `tests_requires` option.

And from ["Why you shouldn't invoke setup.py directly"](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)

> The `setuptools` team no longer wants to be in the business of providing a command line interface and is actively working to become just a library for building packages. 

See the table at https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary, which recommends using `pytest` (as `hamilton` already does) instead of running `python setup.py test`.

Thanks for your time and consideration.

## Todos

None

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [ ] python 3.6
- [x] python 3.7
