### PR TITLE
simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md 
+++ b/.github/PULL_REQUEST_TEMPLATE.md 
@@ -1,13 +1,5 @@
 [Short description explaining the high-level reason for the pull request]
 
-## Additions
-
--
-
-## Removals
-
--
-
 ## Changes
 
 -
@@ -16,16 +8,7 @@
 
 1.
 
-## Screenshots
-If applicable
-
 ## Notes
-
--
-
-## Todos
-
--
 
 ## Checklist
 


### PR DESCRIPTION
This PR proposes some changes to `hamilton`'s pull request template. In my experience as a maintainer on other projects, I've found that the more information an issue / PR template asks for, the more likely it is that people will ignore it entirely.

Would you consider the following simplifications?

* condense "additions", "removals", and "changes" into just "changes"
* condense "todos", "screenshots", and "notes" into just "notes"

I think that this reduced set of sections still provides enough structure to encourage informative pull request descriptions.

Thanks very much for your time and consideration!