### PR TITLE
Extract-columns double-execution bug

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -336,8 +336,12 @@ class FunctionGraph(object):
             computed = {}
 
         def dfs_traverse(node: node.Node, dependency_type: DependencyType = DependencyType.REQUIRED):
+            if node.name in computed:
+                return
+            if node.name in overrides:
+                computed[node.name] = overrides[node.name]
+                return
             for n in node.dependencies:
-
                 if n.name not in computed:
                     _, node_dependency_type = node.input_types[n.name]
                     dfs_traverse(n, node_dependency_type)
@@ -350,9 +354,6 @@ class FunctionGraph(object):
                     return
                 value = inputs[node.name]
             else:
-                if node.name in overrides:
-                    computed[node.name] = overrides[node.name]
-                    return
                 kwargs = {}  # construct signature
                 for dependency in node.dependencies:
                     if dependency.name in computed:

--- a/tests/resources/extract_columns_execution_count.py
+++ b/tests/resources/extract_columns_execution_count.py
@@ -1,0 +1,18 @@
+import collections
+
+import pandas as pd
+
+from hamilton.function_modifiers import extract_columns
+
+outputs = collections.defaultdict(list)
+
+
+@extract_columns('col_1', 'col_2', 'col_3')
+def generate_df(unique_id: str) -> pd.DataFrame:
+    """Function that should be parametrized to form multiple functions"""
+    out = pd.DataFrame({
+        'col_1': [1, 2, 3],
+        'col_2': [4, 5, 6],
+        'col_3': [7, 8, 9]})
+    outputs[unique_id].append(out)
+    return out


### PR DESCRIPTION
We double-execute nodes every once in a while

## Changes
Add a short-circuit in DFS traverse to not double-execute it

## Testing
Ran everything.

## Notes
This might not be the best way to fix this, but its feasible. We should think about why this wasn't short-circuited in the first place.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [ ] python 3.6
- [ ] python 3.7
