### PR TITLE
Fixes has_cycles behavior

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -171,8 +171,8 @@ class Driver(object):
         :param final_vars: the outputs we want to compute.
         :return: boolean True for cycles, False for no cycles.
         """
+        # get graph we'd be executing over
         nodes, user_nodes = self.graph.get_required_functions(final_vars)
-        self.validate_inputs(user_nodes, self.graph.config)
         return self.graph.has_cycles(nodes, user_nodes)
 
 

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -337,10 +337,10 @@ class FunctionGraph(object):
         user_nodes = set()
 
         def dfs_traverse(node: node.Node):
+            nodes.add(node)
             for n in next_nodes_fn(node):
                 if n not in nodes:
                     dfs_traverse(n)
-            nodes.add(node)
             if node.user_defined:
                 user_nodes.add(node)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -298,8 +298,12 @@ def test_function_graph_has_cycles_true():
     nodes = [n for n in all_nodes if not n.user_defined]
     user_nodes = [n for n in all_nodes if n.user_defined]
     assert fg.has_cycles(nodes, user_nodes) is True
-    with pytest.raises(RecursionError):
-        fg.get_required_functions(['A', 'B', 'C'])
+    nodez, user_nodez = fg.get_required_functions(['A', 'B', 'C'])
+    assert nodez == set(nodes + user_nodes)
+    assert user_nodez == set(user_nodes)
+    result = fg.execute([n for n in nodes if n.name == 'B'], overrides={'A': 1, 'D': 2})
+    assert len(result) == 3
+    assert result['B'] == 3
 
 
 def test_function_graph_has_cycles_false():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -301,9 +301,10 @@ def test_function_graph_has_cycles_true():
     required_nodes, required_user_nodes = fg.get_required_functions(['A', 'B', 'C'])
     assert required_nodes == set(nodes + user_nodes)
     assert required_user_nodes == set(user_nodes)
-    result = fg.execute([n for n in nodes if n.name == 'B'], overrides={'A': 1, 'D': 2})
-    assert len(result) == 3
-    assert result['B'] == 3
+    # We don't want to support this behavior officially -- but this works:
+    # result = fg.execute([n for n in nodes if n.name == 'B'], overrides={'A': 1, 'D': 2})
+    # assert len(result) == 3
+    # assert result['B'] == 3
     with pytest.raises(RecursionError):  # throw recursion error when we don't have a way to short circuit
         fg.execute([n for n in nodes if n.name == 'B'])
 

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -1,5 +1,9 @@
+import pytest
+
+from hamilton import base
 from hamilton.driver import Driver
 import tests.resources.very_simple_dag
+import tests.resources.cyclic_functions
 
 
 def test_driver_validate_input_types():
@@ -12,3 +16,23 @@ def test_driver_validate_runtime_input_types():
     dr = Driver({}, tests.resources.very_simple_dag)
     results = dr.raw_execute(['b'], inputs={'a': 1})
     assert results == {'b': 1}
+
+
+def test_driver_has_cycles_true():
+    """Tests that we don't break when detecting cycles from the driver."""
+    dr = Driver({}, tests.resources.cyclic_functions)
+    assert dr.has_cycles(['C'])
+
+
+def test_driver_cycles_execute_override():
+    """Tests that we short circuit a cycle by passing in overrides."""
+    dr = Driver({}, tests.resources.cyclic_functions, adapter=base.SimplePythonGraphAdapter(base.DictResult()))
+    result = dr.execute(['C'], overrides={'D': 1}, inputs={'b': 2, 'c': 2})
+    assert result['C'] == 34
+
+
+def test_driver_cycles_execute_recursion_error():
+    """Tests that we throw a recursion error when we try to execute over a DAG that isn't a DAG."""
+    dr = Driver({}, tests.resources.cyclic_functions, adapter=base.SimplePythonGraphAdapter(base.DictResult()))
+    with pytest.raises(RecursionError):
+        dr.execute(['C'], inputs={'b': 2, 'c': 2})

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -23,12 +23,12 @@ def test_driver_has_cycles_true():
     dr = Driver({}, tests.resources.cyclic_functions)
     assert dr.has_cycles(['C'])
 
-
-def test_driver_cycles_execute_override():
-    """Tests that we short circuit a cycle by passing in overrides."""
-    dr = Driver({}, tests.resources.cyclic_functions, adapter=base.SimplePythonGraphAdapter(base.DictResult()))
-    result = dr.execute(['C'], overrides={'D': 1}, inputs={'b': 2, 'c': 2})
-    assert result['C'] == 34
+# This is possible -- but we don't want to officially support it. Here for documentation purposes.
+# def test_driver_cycles_execute_override():
+#     """Tests that we short circuit a cycle by passing in overrides."""
+#     dr = Driver({}, tests.resources.cyclic_functions, adapter=base.SimplePythonGraphAdapter(base.DictResult()))
+#     result = dr.execute(['C'], overrides={'D': 1}, inputs={'b': 2, 'c': 2})
+#     assert result['C'] == 34
 
 
 def test_driver_cycles_execute_recursion_error():


### PR DESCRIPTION
We should memoize visiting the node before traversing dependencies.
This changes that behavior, changes the test, and checks that overrides
work and don't fail for a cyclic graph. That way we avoid a stack overflow error.

## Changes

- changing when a node is seen when determining the subgraph to execute.

## Testing

1. unit test work

## Notes

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [TODO link to standards]()
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python

- [x] python 3.6
- [x] python 3.7
