### PR TITLE
remove duplicate functools import

### DIFF
--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -1,5 +1,4 @@
 import functools
-import functools
 import inspect
 import typing
 from typing import Dict, Callable, Collection, Tuple, Union, Any, Type


### PR DESCRIPTION
`functools` is imported twice in `function_modifiers.py`.

https://github.com/stitchfix/hamilton/blob/49f11ede9a79478f31b8ded2673ec0f977033562/hamilton/function_modifiers.py#L1-L2

This PR proposes removing one of them.

## Changes

- removes duplicate import of `functools` in `hamilton.function_modifiers`

## Testing

None

## Notes

None

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
