### PR TITLE
Adds parameterized_inputs

### DIFF
--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -85,6 +85,8 @@ class parametrized_input(NodeExpander):
         :param parameter: Parameter to expand on.
         :param variable_inputs: A map of tuple of [parameter names, documentation] to values
         """
+        logger.warning('`parameterized_input` (singular) is deprecated. It will be removed in a 2.0.0 release. '
+                       'Please migrate to using `parameterized_inputs` (plural).')
         self.parameter = parameter
         self.assigned_output = variable_inputs
         for value in variable_inputs.values():

--- a/tests/resources/parametrized_inputs.py
+++ b/tests/resources/parametrized_inputs.py
@@ -1,4 +1,4 @@
-from hamilton.function_modifiers import parametrized_input
+from hamilton.function_modifiers import parametrized_input, parametrized_inputs
 
 
 def input_1() -> int:
@@ -7,6 +7,10 @@ def input_1() -> int:
 
 def input_2() -> int:
     return 2
+
+
+def input_3() -> int:
+    return 3
 
 
 @parametrized_input(
@@ -18,3 +22,38 @@ def input_2() -> int:
 )
 def function_with_multiple_inputs(input_value_tbd: int, static_value: int) -> int:
     return input_value_tbd + static_value
+
+
+# We don't prefer this style of specifying the values. i.e. kwarg with {}.
+@parametrized_inputs(
+    output_12={'input_value_tbd1': 'input_1', 'input_value_tbd2': 'input_2'}
+)
+def function_with_two_parameters(input_value_tbd1: int,
+                                 input_value_tbd2: int,
+                                 static_value: int) -> int:
+    """function_with_multiple_inputs called using {input_value_tbd1} and {input_value_tbd2}
+
+    :return: creates {output_name}
+    """
+    return input_value_tbd1 + input_value_tbd2 + static_value
+
+
+# We prefer this style of specifying the values. i.e. kwarg with dict().
+@parametrized_inputs(
+    output_123=dict(input_value_tbd1='input_1',
+                    input_value_tbd2='input_2',
+                    input_value_tbd3='input_3')
+)
+def function_with_three_parameters(input_value_tbd1: int,
+                                   input_value_tbd2: int,
+                                   input_value_tbd3: int,
+                                   static_value: int) -> int:
+    """function_with_multiple_inputs called using {input_value_tbd1} and {input_value_tbd2} and {input_value_tbd3}
+
+    :param {input_value_tbd1}:
+    :param {input_value_tbd2}:
+    :param {input_value_tbd3}:
+    :param static_value:
+    :return: {output_name}
+    """
+    return input_value_tbd1 + input_value_tbd2 + input_value_tbd3 + static_value

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -224,8 +224,11 @@ def test_end_to_end_with_parametrized_inputs():
     assert results == {
         'input_1': 1,
         'input_2': 2,
+        'input_3': 3,
         'output_1': 1 + 3,
         'output_2': 2 + 3,
+        'output_12': 1 + 2 + 3,
+        'output_123': 1 + 2 + 3 + 3,
         'static_value': 3
     }
 


### PR DESCRIPTION
This change adds `paramterized_inputs` decorator, which
is almost a carbon copy of `paramterized_input` but that it allows
any number of parameters to be mapped.

Why is it a separate class? Well for backwards compatibility
we don't want to break parameterized_input. Should we try to
consolidate them? I think so -- so we should then mark `parameterized_input`
as deprecated and will be removed in a 2.0 release? ✅ 

I should then probably update all documentation to reflect `parameterized_inputs`
and thus the documentation on `paramterized_input` to either be hidden or
non-existant? Hmm. ✅ 


## Changes

- Add parameterized_inputs decorator.
- Deprecates parameterized_input decorator.
- Adjust documentation to promote parameterized_inputs instead.

## Testing

1. unit tests pass.

## Notes
Motivation is a side project and having to write out repetitive functions is laborious -- this is admittedly a power
user mode, but one I think that makes sense to have.
e.g. this looks nice and readable
```python
from hamilton.function_modifiers import parametrized_inputs
import pandas as pd

NUMERIC_FEATURES = ['age', 'height', 'weight', 'body_mass_index', 'transportation_expense',
                    'distance_from_residence_to_work', 'service_time', 'work_load_average_per_day',
                    'hit_target']


@parametrized_inputs(**{f'{k}_mean': dict(feature=k) for k in NUMERIC_FEATURES})
def mean_computer(feature: pd.Series) -> pd.Series:
    """Average of {feature}"""
    return feature.mean()


@parametrized_inputs(**{f'{k}_std_dev': dict(feature=k) for k in NUMERIC_FEATURES})
def std_dev_computer(feature: pd.Series) -> pd.Series:
    """Standard deviation of {feature}"""
    return feature.std()


@parametrized_inputs(**{f'{k}_zero_mean': dict(feature=k, feature_mean=f'{k}_mean') for k in NUMERIC_FEATURES})
def zero_mean_computer(feature: pd.Series, feature_mean: pd.Series) -> pd.Series:
    """Creates zero mean value of {feature} by subtracting {feature_mean}"""
    return feature - feature_mean


@parametrized_inputs(**{f'{k}_zero_mean_unit_var': dict(feature_mean=f'{k}_mean', feature_std_dev=f'{k}_std_dev') 
                        for k in NUMERIC_FEATURES})
def zero_mean_unit_var_computer(feature_mean: pd.Series, feature_std_dev: pd.Series) -> pd.Series:
    """Computes zero mean unit variance of {feature_mean} with {feature_std_dev} to create {output_name}"""
    return feature_mean / feature_std_dev

```

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
