### PR TITLE
Adds Ray Workflow Graph Adapter - implements #67

### DIFF
--- a/examples/ray/hello_world/README.md
+++ b/examples/ray/hello_world/README.md
@@ -11,4 +11,15 @@ File organization:
 * `business_logic.py` houses logic that should be invariant to how hamilton is executed.
 * `data_loaders.py` houses logic to load data for the business_logic.py module. The
 idea is that you'd swap this module out for other ways of loading data.
-*  `run.py` is the script that ties everything together.
+* `run.py` is the script that ties everything together that uses vanilla Ray.
+* `run_rayworkflow.py` is the script that again ties everything together, but this time uses
+[Ray Workflows](https://docs.ray.io/en/latest/workflows/concepts.html) to execute.
+
+# Running the code:
+For the vanilla Ray implementation use:
+
+> python run.py
+
+For the [Ray Workflow](https://docs.ray.io/en/latest/workflows/concepts.html) implementation use:
+
+> python run_rayworkflow.py

--- a/examples/ray/hello_world/run_rayworkflow.py
+++ b/examples/ray/hello_world/run_rayworkflow.py
@@ -13,11 +13,11 @@ if __name__ == '__main__':
     log_setup.setup_logging()
     ray.init()
     workflow.init()
-    module_names = [
-        'data_loaders',  # functions to help load data
-        'business_logic'  # where our important logic lives
-    ]
-    modules = [importlib.import_module(m) for m in module_names]
+    # You can also script module import loading by knowing the module name
+    # See run.py for an example of doing it that way.
+    import data_loaders
+    import business_logic
+    modules = [data_loaders, business_logic]
     initial_columns = {  # could load data here via some other means, or delegate to a module as we have done.
         # 'signups': pd.Series([1, 10, 50, 100, 200, 400]),
         'signups_location': 'some_path',
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     rga = h_ray.RayWorkflowGraphAdapter(result_builder=base.PandasDataFrameResult(),
                                         # Ray will resume a run if possible based on workflow id
                                         workflow_id='hello-world-123')
-    dr = driver.Driver(initial_columns, *modules, adapter=rga)  # can pass in multiple modules
+    dr = driver.Driver(initial_columns, *modules, adapter=rga)
     # we need to specify what we want in the final dataframe.
     output_columns = [
         'spend',

--- a/examples/ray/hello_world/run_rayworkflow.py
+++ b/examples/ray/hello_world/run_rayworkflow.py
@@ -1,0 +1,45 @@
+import importlib
+
+import ray
+from ray import workflow
+
+from hamilton import base
+from hamilton import driver
+from hamilton import log_setup
+from hamilton.experimental import h_ray
+
+
+if __name__ == '__main__':
+    log_setup.setup_logging()
+    ray.init()
+    workflow.init()
+    module_names = [
+        'data_loaders',  # functions to help load data
+        'business_logic'  # where our important logic lives
+    ]
+    modules = [importlib.import_module(m) for m in module_names]
+    initial_columns = {  # could load data here via some other means, or delegate to a module as we have done.
+        # 'signups': pd.Series([1, 10, 50, 100, 200, 400]),
+        'signups_location': 'some_path',
+        # 'spend': pd.Series([10, 10, 20, 40, 40, 50]),
+        'spend_location': 'some_other_path'
+    }
+    rga = h_ray.RayWorkflowGraphAdapter(result_builder=base.PandasDataFrameResult(),
+                                        # Ray will resume a run if possible based on workflow id
+                                        workflow_id='hello-world-123')
+    dr = driver.Driver(initial_columns, *modules, adapter=rga)  # can pass in multiple modules
+    # we need to specify what we want in the final dataframe.
+    output_columns = [
+        'spend',
+        'signups',
+        'avg_3wk_spend',
+        'spend_per_signup',
+        'spend_zero_mean_unit_variance'
+    ]
+    # let's create the dataframe!
+    df = dr.execute(output_columns)
+    # To visualize do `pip install sf-hamilton[visualization]` if you want these to work
+    # dr.visualize_execution(output_columns, './my_dag.dot', {})
+    # dr.display_all_functions('./my_full_dag.dot')
+    print(df.to_string())
+    ray.shutdown()

--- a/graph_adapter_tests/h_ray/test_h_ray.py
+++ b/graph_adapter_tests/h_ray/test_h_ray.py
@@ -12,6 +12,7 @@ from .resources import example_module
 For reference https://docs.ray.io/en/latest/auto_examples/testing-tips.html
 """
 
+
 @pytest.fixture(scope='module')
 def init():
     ray.init(local_mode=True)  # need local mode, else it can't seem to find the h_ray module.

--- a/graph_adapter_tests/h_ray/test_h_ray_workflow.py
+++ b/graph_adapter_tests/h_ray/test_h_ray_workflow.py
@@ -1,0 +1,41 @@
+import tempfile
+
+import pandas as pd
+import pytest
+
+import ray
+from ray import workflow
+
+from hamilton import driver, base
+from hamilton.experimental import h_ray
+
+from .resources import example_module
+
+
+@pytest.fixture(scope='module')
+def init():
+    ray.init(local_mode=True)  # need local mode, else it can't seem to find the h_ray module.
+    yield 'initialized'
+    ray.shutdown()
+
+# This does not work locally -- will ask Ray slack for support.
+# def test_ray_workflow_graph_adapter(init):
+#     with tempfile.TemporaryDirectory() as tmpdirname:
+#         workflow.init(tmpdirname)
+#         initial_columns = {
+#             'signups': pd.Series([1, 10, 50, 100, 200, 400]),
+#             'spend': pd.Series([10, 10, 20, 40, 40, 50]),
+#         }
+#         dr = driver.Driver(initial_columns, example_module,
+#                            adapter=h_ray.RayWorkflowGraphAdapter(base.PandasDataFrameResult(), 'test-123'))
+#         output_columns = [
+#             'spend',
+#             'signups',
+#             'avg_3wk_spend',
+#             'spend_per_signup',
+#         ]
+#         df = dr.execute(output_columns)
+#         assert set(df) == set(output_columns)
+#         expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
+#         pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
+#         # TODO: do some more asserting?

--- a/graph_adapter_tests/h_ray/test_h_ray_workflow.py
+++ b/graph_adapter_tests/h_ray/test_h_ray_workflow.py
@@ -9,33 +9,34 @@ from ray import workflow
 from hamilton import driver, base
 from hamilton.experimental import h_ray
 
-from .resources import example_module
+from graph_adapter_tests.h_ray.resources import example_module
 
 
 @pytest.fixture(scope='module')
 def init():
-    ray.init(local_mode=True)  # need local mode, else it can't seem to find the h_ray module.
+    ray.init()
     yield 'initialized'
     ray.shutdown()
 
+
 # This does not work locally -- will ask Ray slack for support.
-# def test_ray_workflow_graph_adapter(init):
-#     with tempfile.TemporaryDirectory() as tmpdirname:
-#         workflow.init(tmpdirname)
-#         initial_columns = {
-#             'signups': pd.Series([1, 10, 50, 100, 200, 400]),
-#             'spend': pd.Series([10, 10, 20, 40, 40, 50]),
-#         }
-#         dr = driver.Driver(initial_columns, example_module,
-#                            adapter=h_ray.RayWorkflowGraphAdapter(base.PandasDataFrameResult(), 'test-123'))
-#         output_columns = [
-#             'spend',
-#             'signups',
-#             'avg_3wk_spend',
-#             'spend_per_signup',
-#         ]
-#         df = dr.execute(output_columns)
-#         assert set(df) == set(output_columns)
-#         expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
-#         pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
-#         # TODO: do some more asserting?
+def test_ray_workflow_graph_adapter(init):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        workflow.init(tmpdirname)
+        initial_columns = {
+            'signups': pd.Series([1, 10, 50, 100, 200, 400]),
+            'spend': pd.Series([10, 10, 20, 40, 40, 50]),
+        }
+        dr = driver.Driver(initial_columns, example_module,
+                           adapter=h_ray.RayWorkflowGraphAdapter(base.PandasDataFrameResult(), 'test-123'))
+        output_columns = [
+            'spend',
+            'signups',
+            'avg_3wk_spend',
+            'spend_per_signup',
+        ]
+        df = dr.execute(output_columns)
+        assert set(df) == set(output_columns)
+        expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
+        pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
+        # TODO: do some more asserting?

--- a/hamilton/experimental/h_ray.py
+++ b/hamilton/experimental/h_ray.py
@@ -2,6 +2,7 @@ import logging
 import typing
 
 import ray
+from ray import workflow
 
 from hamilton import base
 from hamilton import node
@@ -67,8 +68,87 @@ class RayGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         """
         if logger.isEnabledFor(logging.DEBUG):
             for k, v in outputs.items():
-                logger.debug(f'Got column {k}, with type [{type(v)}].')
+                logger.debug(f'Got output {k}, with type [{type(v)}].')
         # need to wrap our result builder in a remote call and then pass in what we want to build from.
         remote_combine = ray.remote(self.result_builder.build_result).remote(**outputs)
         result = ray.get(remote_combine)  # this materializes the object locally
+        return result
+
+
+class RayWorkflowGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
+    """Class representing what's required to make Hamilton run Ray Workflows
+
+    Use `pip install sf-hamilton[ray]` to get the dependencies required to run this.
+
+    Ray workflows is a more robust way to scale computation for any type of Hamilton graph.
+
+    # What's the difference between this and RayGraphAdapter?
+    * Ray workflows offer durable computation. That is, they save and checkpoint each function.
+    * This enables one to run a workflow, and not have to restart it if something fails, assuming correct
+    Ray workflow usage.
+
+    # Tips - see https://docs.ray.io/en/latest/workflows/basics.html for the source of the following:
+    1. Functions should be idempotent.
+    2. The workflow ID is what Ray uses to try to resume/restart if run a second time.
+    3. Nothing is run until the entire DAG is walked and setup and build_result is called.
+
+    # Notes on scaling:
+      - Multi-core on single machine ✅
+      - Distributed computation on a Ray cluster ✅
+      - Scales to any size of data ⛔️; you are LIMITED by the memory on the instance/computer 💻.
+
+    # Function return object types supported:
+     - Works for any python object that can be serialized by the Ray framework. ✅
+
+    # Pandas?
+     - ⛔️ Ray DOES NOT do anything special about Pandas.
+
+    DISCLAIMER -- this class is experimental, so signature changes are a possibility!
+    """
+
+    def __init__(self, result_builder: base.ResultMixin, workflow_id: str):
+        """Constructor
+
+        :param result_builder: Required. An implementation of base.ResultMixin.
+        :param workflow_id: Required. An ID to give the ray workflow to identify it for durability purposes.
+        :param max_retries: Optional. The function will be retried for the given number of times if an
+            exception is raised.
+        """
+        self.result_builder = result_builder
+        self.workflow_id = workflow_id
+        if not self.result_builder:
+            raise ValueError('Error: ResultMixin object required. Please pass one in for `result_builder`.')
+
+    @staticmethod
+    def check_input_type(node_type: typing.Type, input_value: typing.Any) -> bool:
+        # NOTE: the type of a raylet is unknown until they are computed
+        if isinstance(input_value, ray._raylet.ObjectRef):
+            return True
+        return node_type == typing.Any or isinstance(input_value, node_type)
+
+    @staticmethod
+    def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:
+        return node_type == input_type
+
+    def execute_node(self, node: node.Node, kwargs: typing.Dict[str, typing.Any]) -> typing.Any:
+        """Function that is called as we walk the graph to determine how to execute a hamilton function.
+
+        :param node: the node from the graph.
+        :param kwargs: the arguments that should be passed to it.
+        :return: returns a ray object reference.
+        """
+        return workflow.step(node.callable).step(**kwargs)
+
+    def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:
+        """Builds the result and brings it back to this running process.
+
+        :param outputs: the dictionary of key -> Union[ray object reference | value]
+        :return: The type of object returned by self.result_builder.
+        """
+        if logger.isEnabledFor(logging.DEBUG):
+            for k, v in outputs.items():
+                logger.debug(f'Got output {k}, with type [{type(v)}].')
+        # need to wrap our result builder in a remote call and then pass in what we want to build from.
+        remote_combine = workflow.step(self.result_builder.build_result).step(**outputs)
+        result = remote_combine.run(workflow_id=self.workflow_id)  # this materializes the object locally
         return result


### PR DESCRIPTION
I believe this is the MVP required to get Ray workflows running and fulfill #67 .

It runs locally -- and if you re-run things with the same workflow-id, it'll
retrieve/resume the workflow from wherever it finished.


## Changes

- Adds new Graph Adapter.
- Adds to Ray hello world

## Testing

1. Runs locally.

## Notes
Ray workflow is considered in Alpha -- so things might change - https://docs.ray.io/en/latest/workflows/concepts.html


## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [x] python 3.7
