### PR TITLE
Fixes parameterized_inputs typo

### DIFF
--- a/decorators.md
+++ b/decorators.md
@@ -29,16 +29,17 @@ distinct outputs. The _parameter_ key word argument has to match one of the argu
 the arguments are pulled from outside the DAG. The _assigned_output_ key word argument takes in a dictionary of
 tuple(Output Name, Documentation string) -> value.
 
-## @parametrized_inputs
+## @parameterized_inputs
 Expands a single function into _n_, each of which corresponds to a function in which the parameters specified are mapped
 to the specified inputs. Note this decorator and `@parametrized` are quite similar, except that
 the input here is another DAG node(s), i.e. column/input, rather than a specific scalar/static value.
+
 ```python
 import pandas as pd
-from hamilton.function_modifiers import parametrized_inputs
+from hamilton.function_modifiers import parameterized_inputs
 
 
-@parametrized_inputs(
+@parameterized_inputs(
     D_ELECTION_2016_shifted=dict(one_off_date='D_ELECTION_2016'),
     SOME_OUTPUT_NAME=dict(one_off_date='SOME_INPUT_NAME')
 )

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -129,7 +129,7 @@ class parametrized_input(NodeExpander):
                 f'Annotation is invalid -- no such parameter {self.parameter} in function {fn}')
 
 
-class parametrized_inputs(NodeExpander):
+class parameterized_inputs(NodeExpander):
     RESERVED_KWARG = 'output_name'
 
     def __init__(self, **parameterization: Dict[str, Dict[str, str]]):
@@ -137,7 +137,7 @@ class parametrized_inputs(NodeExpander):
         some subset of the specified parameters with specific inputs.
 
         Note this decorator and `@parametrized_input` are similar, except this one allows multiple
-        parameters to be mapped to multiple function arguments.
+        parameters to be mapped to multiple function arguments (and it fixes the spelling mistake).
 
         `parameterized_inputs` allows you keep your code DRY by reusing the same function but replace the inputs
         to create multiple corresponding distinct outputs. We see here that `parameterized_inputs` allows you to keep
@@ -152,7 +152,7 @@ class parametrized_inputs(NodeExpander):
         """
         self.parametrization = parameterization
         if not parameterization:
-            raise ValueError(f'Cannot pass empty/None dictionary to parametrized_inputs')
+            raise ValueError(f'Cannot pass empty/None dictionary to parameterized_inputs')
         for output, mappings in parameterization.items():
             if not mappings:
                 raise ValueError(f'Error, {output} has a none/empty dictionary mapping. Please fill it.')

--- a/tests/resources/parametrized_inputs.py
+++ b/tests/resources/parametrized_inputs.py
@@ -1,4 +1,4 @@
-from hamilton.function_modifiers import parametrized_input, parametrized_inputs
+from hamilton.function_modifiers import parametrized_input, parameterized_inputs
 
 
 def input_1() -> int:
@@ -25,7 +25,7 @@ def function_with_multiple_inputs(input_value_tbd: int, static_value: int) -> in
 
 
 # We don't prefer this style of specifying the values. i.e. kwarg with {}.
-@parametrized_inputs(
+@parameterized_inputs(
     output_12={'input_value_tbd1': 'input_1', 'input_value_tbd2': 'input_2'}
 )
 def function_with_two_parameters(input_value_tbd1: int,
@@ -39,7 +39,7 @@ def function_with_two_parameters(input_value_tbd1: int,
 
 
 # We prefer this style of specifying the values. i.e. kwarg with dict().
-@parametrized_inputs(
+@parameterized_inputs(
     output_123=dict(input_value_tbd1='input_1',
                     input_value_tbd2='input_2',
                     input_value_tbd3='input_3')

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -114,7 +114,7 @@ def test_parametrized_input():
 
 def test_parametrized_inputs_validate_param_name():
     """Tests validate function of parameterized_inputs capturing bad param name usage."""
-    annotation = function_modifiers.parametrized_inputs(
+    annotation = function_modifiers.parameterized_inputs(
         parameterization={
             'test_1': dict(parameterfoo='input_1'),
         })
@@ -128,7 +128,7 @@ def test_parametrized_inputs_validate_param_name():
 
 def test_parametrized_inputs_validate_reserved_param():
     """Tests validate function of parameterized_inputs catching reserved param usage."""
-    annotation = function_modifiers.parametrized_inputs(
+    annotation = function_modifiers.parameterized_inputs(
         **{
             'test_1': dict(parameter2='input_1'),
         })
@@ -142,7 +142,7 @@ def test_parametrized_inputs_validate_reserved_param():
 
 def test_parametrized_inputs_validate_bad_doc_string():
     """Tests validate function of parameterized_inputs catching bad doc string."""
-    annotation = function_modifiers.parametrized_inputs(
+    annotation = function_modifiers.parameterized_inputs(
         **{
             'test_1': dict(parameter2='input_1'),
         })
@@ -155,7 +155,7 @@ def test_parametrized_inputs_validate_bad_doc_string():
 
 
 def test_parametrized_inputs():
-    annotation = function_modifiers.parametrized_inputs(
+    annotation = function_modifiers.parameterized_inputs(
         **{
             'test_1': dict(parameter1='input_1', parameter2='input_2'),
             'test_2': dict(parameter1='input_2', parameter2='input_1'),


### PR DESCRIPTION
It was parametrized_inputs, now it correctly has
the missing `e` in it.

## Changes

-

## Testing

1.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
