### PR TITLE
[ci] remove comments in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,6 @@ jobs:
     docker:
       - image: circleci/python:3.6
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -42,10 +38,6 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -76,10 +68,6 @@ jobs:
     docker:
       - image: circleci/python:3.8
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -110,10 +98,6 @@ jobs:
     docker:
       - image: circleci/python:3.9
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -154,10 +138,6 @@ jobs:
     docker:
       - image: circleci/python:3.6
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -181,10 +161,6 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -208,10 +184,6 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:
@@ -235,10 +207,6 @@ jobs:
     docker:
       - image: cimg/openjdk:14.0   # need java on it
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR proposes removing repeated comments in the project's CI config which are unrelated to the project. 

## Changes

- Removes `Specify service dependencies here` comments

## Testing

None

## Notes

It seems that these comments are not related to `hamilton`, and might have been from some template config. I don't believe it's necessary to keep them in the project's CI config, and that removing them will reduce the effort necessary to understand that config.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
