### PR TITLE
Fixes tag type hints and doc string

### DIFF
--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -637,7 +637,12 @@ class tag(NodeDecorator):
         'dag',
     ]  # Anything that starts with any of these is banned, the framework reserves the right to manage it
 
-    def __init__(self, **tags: Dict[str, str]):
+    def __init__(self, **tags: str):
+        """Constructor for adding tag annotations to a function.
+
+        :param tags: the keys are always going to be strings, so the type annotation here means the values are strings.
+            Implicitly this is `Dict[str, str]` but the PEP guideline is to only annotate it with `str`.
+        """
         self.tags = tags
 
     def decorate_node(self, node_: node.Node) -> node.Node:

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -601,18 +601,32 @@ class config(NodeResolver):
 
 class tag(NodeDecorator):
     """Decorator class that adds a tag to a node. Tags take the form of key/value pairings.
-    Tags can have dots to specify namespaces (keys with dots), but this is usually reserved for special cases (E.G. subdecorators)
-    that utilize them. These are passed in as kwargs, so usually they'll be un-namespaced.
+    Tags can have dots to specify namespaces (keys with dots), but this is usually reserved for special cases
+    (E.G. subdecorators) that utilize them. Usually one will pass in tags as kwargs, so we expect tags to
+    be un-namespaced in most uses.
 
-    Currently tag values are restricted to allowing strings only, although we may consider changing the in the future (E.G. thinking of lists)
+    That is using:
+    > @tag(my_tag='tag_value')
+    > def my_function(...) -> ...:
+    is un-namespaced because you cannot put a `.` in the keyword part (the part before the '=').
 
-    Also, we reserve the right to add purely positional arguments in this as well.
+    But using:
+    > @tag(**{'my.tag': 'tag_value'})
+    > def my_function(...) -> ...:
+    allows you to add dots that allow you to namespace your tags.
 
-    @tag(foo='bar', bar=baz)
-    def my_function(...) -> ...:
-       ...
+    Currently, tag values are restricted to allowing strings only, although we may consider changing the in the future
+    (E.G. thinking of lists).
 
-    The framework reserves the right to a certain set of top-level prefixes (E.G. any tag where the top level is RESERVED_TAG_PREFIX).
+    Hamilton also reserves the right to change the following:
+    * adding purely positional arguments
+    * not allowing users to use a certain set of top-level prefixes (E.G. any tag where the top level is one of the
+      values in RESERVED_TAG_PREFIX).
+
+    Example usage:
+    > @tag(foo='bar', a_tag_key='a_tag_value', **{'namespace.tag_key': 'tag_value'})
+    > def my_function(...) -> ...:
+    >   ...
     """
 
     RESERVED_TAG_NAMESPACES = [
@@ -623,7 +637,7 @@ class tag(NodeDecorator):
         'dag',
     ]  # Anything that starts with any of these is banned, the framework reserves the right to manage it
 
-    def __init__(self, **tags: str):
+    def __init__(self, **tags: Dict[str, str]):
         self.tags = tags
 
     def decorate_node(self, node_: node.Node) -> node.Node:

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -50,7 +50,7 @@ class Node(object):
         :param callabl: the actual function callable.
         :param node_source: whether this is something someone has to pass in.
         :param input_types: the input parameters and their types.
-        :param tags: the set of tags that this node contains. This is a nested dictionary of keys/values.
+        :param tags: the set of tags that this node contains.
         """
         if tags is None:
             tags = dict()
@@ -123,7 +123,7 @@ class Node(object):
         return self._depended_on_by
 
     @property
-    def tags(self) -> Collection[str]:
+    def tags(self) -> Dict[str, str]:
         return self._tags
 
     def __hash__(self):
@@ -143,6 +143,7 @@ class Node(object):
                 self._name == other.name and
                 self._type == other.type and
                 self._doc == other.documentation and
+                self._tags == other.tags and
                 self.user_defined == other.user_defined and
                 [n.name for n in self.dependencies] == [o.name for o in other.dependencies] and
                 [n.name for n in self.depended_on_by] == [o.name for o in other.depended_on_by] and

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -597,6 +597,7 @@ def test_tags_valid_key(key):
 def test_tags_invalid_value(value):
     assert not function_modifiers.tag._value_allowed(value)
 
+
 @pytest.mark.parametrize(
     'value',
     [


### PR DESCRIPTION
The type hints weren't correct. This fixes them,
and then expands on the class documentation to
ensure I can remember how to use the functionality.

## Changes

- fixes type hints.
- adds to doc string for tag decorator class.

## Testing

1. N/A

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

N/A
