### PR TITLE
Adds some basic graph query functions to driver

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -209,42 +209,42 @@ class Driver(object):
         nodes, user_nodes = self.graph.get_upstream_nodes(final_vars)
         return self.graph.has_cycles(nodes, user_nodes)
 
-    def what_is_downstream_of(self, *function_names: str) -> List[Variable]:
+    def what_is_downstream_of(self, *node_names: str) -> List[Variable]:
         """Tells you what is downstream of this function(s), i.e. node(s).
 
-        :param function_names: names of function(s) that are starting points for traversing the graph.
+        :param node_names: names of function(s) that are starting points for traversing the graph.
         :return: list of "variables" (i.e. nodes), inclusive of the function names, that are downstream of the passed
                 in function names.
         """
-        downstream_nodes = self.graph.get_impacted_nodes(list(function_names))
+        downstream_nodes = self.graph.get_impacted_nodes(list(node_names))
         return [Variable(node.name, node.type, node.tags) for node in downstream_nodes]
 
-    def display_downstream_of(self, *function_names: str, output_file_path: str, render_kwargs: dict):
+    def display_downstream_of(self, *node_names: str, output_file_path: str, render_kwargs: dict):
         """Creates a visualization of the DAG starting from the passed in function name(s).
 
         Note: for any "node" visualized, we will also add its parents to the visualization as well, so
         there could be more nodes visualized than strictly what is downstream of the passed in function name(s).
 
-        :param function_names: names of function(s) that are starting points for traversing the graph.
+        :param node_names: names of function(s) that are starting points for traversing the graph.
         :param output_file_path: the full URI of path + file name to save the dot file to.
             E.g. 'some/path/graph.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
         """
-        downstream_nodes = self.graph.get_impacted_nodes(list(function_names))
+        downstream_nodes = self.graph.get_impacted_nodes(list(node_names))
         try:
             self.graph.display(downstream_nodes, set(), output_file_path, render_kwargs=render_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 
-    def what_is_upstream_of(self, *function_names: str) -> List[Variable]:
+    def what_is_upstream_of(self, *node_names: str) -> List[Variable]:
         """Tells you what is upstream of this function(s), i.e. node(s).
 
-        :param function_names: names of function(s) that are starting points for traversing the graph backwards.
+        :param node_names: names of function(s) that are starting points for traversing the graph backwards.
         :return: list of "variables" (i.e. nodes), inclusive of the function names, that are upstream of the passed
                 in function names.
         """
-        upstream_nodes, _ = self.graph.get_upstream_nodes(list(function_names))
+        upstream_nodes, _ = self.graph.get_upstream_nodes(list(node_names))
         return [Variable(node.name, node.type, node.tags) for node in upstream_nodes]
 
 

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -209,6 +209,44 @@ class Driver(object):
         nodes, user_nodes = self.graph.get_upstream_nodes(final_vars)
         return self.graph.has_cycles(nodes, user_nodes)
 
+    def what_is_downstream_of(self, *function_names: str) -> List[Variable]:
+        """Tells you what is downstream of this function(s), i.e. node(s).
+
+        :param function_names: names of function(s) that are starting points for traversing the graph.
+        :return: list of "variables" (i.e. nodes), inclusive of the function names, that are downstream of the passed
+                in function names.
+        """
+        downstream_nodes = self.graph.get_impacted_nodes(list(function_names))
+        return [Variable(node.name, node.type, node.tags) for node in downstream_nodes]
+
+    def display_downstream_of(self, *function_names: str, output_file_path: str, render_kwargs: dict):
+        """Creates a visualization of the DAG starting from the passed in function name(s).
+
+        Note: for any "node" visualized, we will also add its parents to the visualization as well, so
+        there could be more nodes visualized than strictly what is downstream of the passed in function name(s).
+
+        :param function_names: names of function(s) that are starting points for traversing the graph.
+        :param output_file_path: the full URI of path + file name to save the dot file to.
+            E.g. 'some/path/graph.dot'
+        :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
+            If you do not want to view the file, pass in `{'view':False}`.
+        """
+        downstream_nodes = self.graph.get_impacted_nodes(list(function_names))
+        try:
+            self.graph.display(downstream_nodes, set(), output_file_path, render_kwargs=render_kwargs)
+        except ImportError as e:
+            logger.warning(f'Unable to import {e}', exc_info=True)
+
+    def what_is_upstream_of(self, *function_names: str) -> List[Variable]:
+        """Tells you what is upstream of this function(s), i.e. node(s).
+
+        :param function_names: names of function(s) that are starting points for traversing the graph backwards.
+        :return: list of "variables" (i.e. nodes), inclusive of the function names, that are upstream of the passed
+                in function names.
+        """
+        upstream_nodes, _ = self.graph.get_upstream_nodes(list(function_names))
+        return [Variable(node.name, node.type, node.tags) for node in upstream_nodes]
+
 
 if __name__ == '__main__':
     """some example test code"""

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -107,14 +107,16 @@ class Driver(object):
                 overrides: Dict[str, Any] = None,
                 display_graph: bool = False,
                 inputs: Dict[str, Any] = None,
-                ) -> pd.DataFrame:
+                ) -> Any:
         """Executes computation.
 
-        :param final_vars: the final list of variables we want in the data frame.
-        :param overrides: the user defined input variables.
+        :param final_vars: the final list of variables we want to compute.
+        :param overrides: values that will override "nodes" in the DAG.
         :param display_graph: DEPRECATED. Whether we want to display the graph being computed.
         :param inputs: Runtime inputs to the DAG.
-        :return: a data frame consisting of the variables requested.
+        :return: an object consisting of the variables requested, matching the type returned by the GraphAdapter.
+            See constructor for how the GraphAdapter is initialized. The default one right now returns a pandas
+            dataframe.
         """
         if display_graph:
             logger.warning('display_graph=True is deprecated. It will be removed in the 2.0.0 release. '


### PR DESCRIPTION
Thinking of how to use tags, or the workflow to use them, I'm envisioning

1. query for all nodes.
2. filter by tags.
3. use those nodes then for other purposes.

Ideally we could instead provide an API that you use tags to
query by instead, but I don't have a good feel for what that
should be right now.

Anyway, I'm thinking it'd be useful to ask questions,
given a set of function names, what is downstream or
upstream of them.

I only added visualization of the downstream because,
you can visualize what's upstream by using the
visualize_execution function.

## Changes

- Adds some driver functions for asking what is upstream and downstream of some functions.

## Testing

1. Worked locally.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
