### PR TITLE
Adds example on how to use the tags exposed by the driver

### DIFF
--- a/decorators.md
+++ b/decorators.md
@@ -218,7 +218,7 @@ To make this easier, we have a few more `@config` decorators:
 ## @tag
 
 Allows you to attach metadata to a node (any node decorated with the function).
-A common use of this is to enable marking nodes as part of some data product.
+A common use of this is to enable marking nodes as part of some data product, or for GDPR/privacy purposes.
 
 For instance:
 
@@ -229,10 +229,22 @@ from hamilton.function_modifiers import tag
 def intermediate_column() -> pd.Series:
     pass
 
-@tag(data_product='final')
+@tag(data_product='final', pii='true')
 def final_column(intermediate_column: pd.Series) -> pd.Series:
     pass
 ```
 
-Using the `list_available_variables()` capability exposes tags along with variables,
-enabling querying of the available variables for specific tag matches.
+### How do I query by tags?
+Right now, we don't have a specific interface to query by tags, however we do expose them via the driver.
+Using the `list_available_variables()` capability exposes tags along with their names & types,
+enabling querying of the available outputs for specific tag matches.
+E.g.
+```python
+
+from hamilton import driver
+dr = driver.Driver(...)  # create driver as required
+all_possible_outputs = dr.list_available_variables()
+desired_outputs = [o.name for o in all_possible_outputs
+                   if 'my_tag_value' == o.tags.get('my_tag_key')]
+output = dr.execute(desired_outputs)
+```

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -157,9 +157,9 @@ class Driver(object):
         return outputs
 
     def list_available_variables(self) -> List[Variable]:
-        """Returns available variables.
+        """Returns available variables, i.e. outputs.
 
-        :return: list of available variables.
+        :return: list of available variables (i.e. outputs).
         """
         return [Variable(node.name, node.type, node.tags) for node in self.graph.get_nodes()]
 


### PR DESCRIPTION
So that people know how to extract the information back out afterwards.

Also note, the function in the driver is probably poorly named. We don't use the
term "variables" anywhere, yet here we do. It should really be called, `list_available_outputs()`
or something like that.


## Changes

- Adds documentation

## Testing

1. N/A

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
N/A

### Python - local testing

N/A
