### PR TITLE
Exposes passing kwargs to graphviz object

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -165,16 +165,20 @@ class Driver(object):
         """
         return [Variable(node.name, node.type, node.tags) for node in self.graph.get_nodes()]
 
-    def display_all_functions(self, output_file_path: str, render_kwargs: dict = None):
+    def display_all_functions(self, output_file_path: str, render_kwargs: dict = None, graphviz_kwargs: dict = None):
         """Displays the graph of all functions loaded!
 
         :param output_file_path: the full URI of path + file name to save the dot file to.
             E.g. 'some/path/graph-all.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
+            See https://graphviz.readthedocs.io/en/stable/api.html#graphviz.Graph.render for other options.
+        :param graphviz_kwargs: Optional. Kwargs to be passed to the graphviz graph object to configure it.
+            E.g. dict(graph_attr={'ratio': '1'}) will set the aspect ratio to be equal of the produced image.
+            See https://graphviz.org/doc/info/attrs.html for options.
         """
         try:
-            self.graph.display_all(output_file_path, render_kwargs)
+            self.graph.display_all(output_file_path, render_kwargs, graphviz_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 
@@ -182,7 +186,8 @@ class Driver(object):
                             final_vars: List[str],
                             output_file_path: str,
                             render_kwargs: dict,
-                            inputs: Dict[str, Any] = None):
+                            inputs: Dict[str, Any] = None,
+                            graphviz_kwargs: dict = None):
         """Visualizes Execution.
 
         Note: overrides are not handled at this time.
@@ -192,12 +197,17 @@ class Driver(object):
             E.g. 'some/path/graph.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
+            See https://graphviz.readthedocs.io/en/stable/api.html#graphviz.Graph.render for other options.
         :param inputs: Optional. Runtime inputs to the DAG.
+        :param graphviz_kwargs: Optional. Kwargs to be passed to the graphviz graph object to configure it.
+            E.g. dict(graph_attr={'ratio': '1'}) will set the aspect ratio to be equal of the produced image.
+            See https://graphviz.org/doc/info/attrs.html for options.
         """
         nodes, user_nodes = self.graph.get_upstream_nodes(final_vars, inputs)
         self.validate_inputs(user_nodes, inputs)
         try:
-            self.graph.display(nodes, user_nodes, output_file_path, render_kwargs=render_kwargs)
+            self.graph.display(nodes, user_nodes, output_file_path,
+                               render_kwargs=render_kwargs, graphviz_kwargs=graphviz_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 
@@ -221,7 +231,11 @@ class Driver(object):
         downstream_nodes = self.graph.get_impacted_nodes(list(node_names))
         return [Variable(node.name, node.type, node.tags) for node in downstream_nodes]
 
-    def display_downstream_of(self, *node_names: str, output_file_path: str, render_kwargs: dict):
+    def display_downstream_of(self,
+                              *node_names: str,
+                              output_file_path: str,
+                              render_kwargs: dict,
+                              graphviz_kwargs: dict):
         """Creates a visualization of the DAG starting from the passed in function name(s).
 
         Note: for any "node" visualized, we will also add its parents to the visualization as well, so
@@ -232,10 +246,13 @@ class Driver(object):
             E.g. 'some/path/graph.dot'
         :param render_kwargs: a dictionary of values we'll pass to graphviz render function. Defaults to viewing.
             If you do not want to view the file, pass in `{'view':False}`.
+        :param graphviz_kwargs: Kwargs to be passed to the graphviz graph object to configure it.
+            E.g. dict(graph_attr={'ratio': '1'}) will set the aspect ratio to be equal of the produced image.
         """
         downstream_nodes = self.graph.get_impacted_nodes(list(node_names))
         try:
-            self.graph.display(downstream_nodes, set(), output_file_path, render_kwargs=render_kwargs)
+            self.graph.display(downstream_nodes, set(), output_file_path,
+                               render_kwargs=render_kwargs, graphviz_kwargs=graphviz_kwargs)
         except ImportError as e:
             logger.warning(f'Unable to import {e}', exc_info=True)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -366,6 +366,7 @@ def test_create_graphviz_graph():
     # why? because for some reason given the same graph, the output file isn't deterministic.
     expected = sorted(['// test-graph',
                        'digraph {',
+                       '\tgraph [ratio=1]',
                        '\tB [label=B]',
                        '\tA [label=A]',
                        '\tc [label=c]',
@@ -381,7 +382,7 @@ def test_create_graphviz_graph():
                        ''])
     if '' in expected:
         expected.remove('')
-    digraph = graph.create_graphviz_graph(nodes, user_nodes, 'test-graph')
+    digraph = graph.create_graphviz_graph(nodes, user_nodes, 'test-graph', dict(graph_attr={'ratio': '1'}))
     actual = sorted(str(digraph).split('\n'))
     if '' in actual:
         actual.remove('')


### PR DESCRIPTION
This should be a backwards compatible API change for everything.

To be able to control, for instance the ratio, of the produced image,
it's not a render time argument. Instead, it's a property of the graph.
To be able to manipulate it, we need to wire through passing in attributes.
e.g. https://graphviz.org/doc/info/attrs.html shows what could be set.

These attributes are either graph, node, or edge attributes.
The kwargs I'm specifically trying to expose are:
```
graph_attr – Mapping of (attribute, value) pairs for the graph.
node_attr – Mapping of (attribute, value) pairs set for all nodes.
edge_attr – Mapping of (attribute, value) pairs set for all edges.
```
The above was taken from https://graphviz.readthedocs.io/en/stable/api.html?highlight=ratio#digraph.

Note, this will  enable anything else to be also passed to the graph, which I
think is a useful thing too. Since that will allow someone who knows graphviz
to really customize it I think.

## Changes

- Adds a `graphviz_kwargs` parameter and wires it through to all the displays.

## Testing

1. Ran local hello world script passing in `graphviz_kwargs`.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [X] python 3.7
