### PR TITLE
Fixes SimplePythonDataFrameGraphAdapter.check_input_type

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -141,6 +141,10 @@ class SimplePythonDataFrameGraphAdapter(HamiltonGraphAdapter, PandasDataFrameRes
             return True
         elif typing_inspect.is_typevar(node_type):  # skip runtime comparison for now.
             return True
+        elif typing_inspect.is_generic_type(node_type) and typing_inspect.get_origin(node_type) == type(input_value):
+            return True
+        elif node_type == type(input_value):
+            return True
         return False
 
     @staticmethod

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@ import collections
 import typing
 
 import numpy as np
+import pandas as pd
 from numpy import testing
 import pytest
 
@@ -45,3 +46,62 @@ def test_SimplePythonGraphAdapter():
     expected = {'a': 'b', 'esoteric': 'function'}
     actual = spga.build_result(**cols)
     assert actual == expected
+
+
+T = typing.TypeVar('T')
+
+
+@pytest.mark.parametrize('node_type,input_value', [
+    (typing.Any, None),
+    (pd.Series, pd.Series([1, 2, 3])),
+    (T, None),
+    (typing.List, []),
+    (typing.Dict, {}),
+    (dict, {}),
+    (list, []),
+    (int, 1),
+    (float, 1.0),
+    (str, 'abc'),
+], ids=[
+    'test-any',
+    'test-subclass',
+    'test-typevar',
+    'test-generic-list',
+    'test-generic-dict',
+    'test-type-match-dict',
+    'test-type-match-list',
+    'test-type-match-int',
+    'test-type-match-float',
+    'test-type-match-str'
+])
+def test_SimplePythonDataFrameGraphAdapter_check_input_type_match(node_type, input_value):
+    """Tests check_input_type of SimplePythonDataFrameGraphAdapter"""
+    adapter = base.SimplePythonDataFrameGraphAdapter()
+    actual = adapter.check_input_type(node_type, input_value)
+    assert actual is True
+
+
+@pytest.mark.parametrize('node_type,input_value', [
+    (pd.DataFrame, pd.Series([1, 2, 3])),
+    (typing.List, {}),
+    (typing.Dict, []),
+    (dict, []),
+    (list, {}),
+    (int, 1.0),
+    (float, 1),
+    (str, 0),
+], ids=[
+    'test-subclass',
+    'test-generic-list',
+    'test-generic-dict',
+    'test-type-match-dict',
+    'test-type-match-list',
+    'test-type-match-int',
+    'test-type-match-float',
+    'test-type-match-str',
+])
+def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, input_value):
+    """Tests check_input_type of SimplePythonDataFrameGraphAdapter"""
+    adapter = base.SimplePythonDataFrameGraphAdapter()
+    actual = adapter.check_input_type(node_type, input_value)
+    assert actual is False


### PR DESCRIPTION
We were missing some explicit type checks against generic types.
This fixes that and adds some unit tests to verify behavior.

## Changes

- Fixes SimplePythonDataFrameGraphAdapter.check_input_type

## Testing

1. Added unit tests to validate before and after.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [x] python 3.9
