### PR TITLE
Switches documentation to point to Slack instead of Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Stitch Fix Hamilton Open Source Discord Server
-    url: https://discord.gg/wCqxqBqn73
-    about: We are piloting using discord for chat. Feel free to try asking questions there first.
+  - name: Stitch Fix Hamilton Open Source Slack Server
+    url: https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg
+    about: We are piloting using slack for chat. Feel free to try asking questions there first.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For the backstory on how Hamilton came about, see our [blog post!](https://multi
 
 # Getting Started
 Here's a quick getting started guide to get you up and running in less than 15 minutes.
-If you need help join our [discord](https://discord.gg/wCqxqBqn73) community to chat/ask Qs/etc.
+If you need help join our [slack](https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg) community to chat/ask Qs/etc.
 For the latest updates, follow us on [twitter](https://twitter.com/hamilton_os)!
 
 ## Installation
@@ -125,8 +125,8 @@ You should see the following image if you ran `dr.visualize_execution(output_col
 
 Congratulations - you just created your Hamilton dataflow that created a dataframe!
 
-# Discord Community
-We have a small but active community on [discord](https://discord.gg/wCqxqBqn73). Come join us!
+# Slack Community
+We have a small but active community on [slack](https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg). Come join us!
 
 # License
 Hamilton is released under the [BSD 3-Clause Clear License](LICENSE). If you need to get in touch about something,
@@ -159,7 +159,7 @@ In general we prescribe the following:
 2. Familiarize yourself with some of the [Hamilton decorators](decorators.md). They will help keep your code DRY.
 3. Start creating Hamilton Functions that represent your work. We suggest grouping them in modules where it makes sense.
 4. Write a simple script so that you can easily run things end to end.
-5. Join our [discord](https://discord.gg/wCqxqBqn73) community to chat/ask Qs/etc.
+5. Join our [Slack](https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg) community to chat/ask Qs/etc.
 
 For the backstory on Hamilton we invite you to watch a roughly-9 minute lightning talk on it that we gave at the apply conference:
 [video](https://www.youtube.com/watch?v=B5Zp_30Knoo), [slides](https://www.slideshare.net/StefanKrawczyk/hamilton-a-micro-framework-for-creating-dataframes).

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -65,5 +65,5 @@ Now that you've pushed to pypi, announce your release! We plan to automate this,
 
 1. Create a github release (select auto-generate release for painless text generation). Create a tag that's called `sf-hamilton-{version_string}`.
 See [1.2.0](https://github.com/stitchfix/hamilton/releases/tag/sf-hamilton-1.2.0) for an example.
-2. Announce on the #releases channel in discord, following the format presented there.
+2. Announce on the #announcements channel in slack, following the format presented there.
 3. Thanks for contributing!

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Here you'll find some very simple hello world type examples.
 
 If you have questions, or need help with these examples,
-join us on [discord](https://discord.gg/wCqxqBqn73), and we'll try to help!
+join us on [slack](https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg), and we'll try to help!
 
 ## Show casing scaling Pandas
 The `hello_world` folder shows a simple example of how to create a Hamilton DAG and run it.

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -16,4 +16,4 @@ To run things:
 ```
 
 If you have questions, or need help with this example,
-join us on [discord](https://discord.gg/wCqxqBqn73), and we'll try to help!
+join us on [slack](https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg), and we'll try to help!

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -12,10 +12,10 @@ from dataclasses import dataclass, field
 
 from hamilton import node
 
-DISCORD_ERROR_MESSAGE = (
+SLACK_ERROR_MESSAGE = (
     '-------------------------------------------------------------------\n'
     'Oh no an error! Need help with Hamilton?\n'
-    'Join our discord and ask for help! https://discord.gg/wCqxqBqn73\n'
+    'Join our slack and ask for help! https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg\n'
     '-------------------------------------------------------------------\n'
 )
 
@@ -56,7 +56,7 @@ class Driver(object):
         try:
             self.graph = graph.FunctionGraph(*modules, config=config, adapter=adapter)
         except Exception as e:
-            logger.error(DISCORD_ERROR_MESSAGE)
+            logger.error(SLACK_ERROR_MESSAGE)
             raise e
         self.adapter = adapter
 
@@ -125,7 +125,7 @@ class Driver(object):
             outputs = self.raw_execute(final_vars, overrides, display_graph, inputs=inputs)
             return self.adapter.build_result(**outputs)
         except Exception as e:
-            logger.error(DISCORD_ERROR_MESSAGE)
+            logger.error(SLACK_ERROR_MESSAGE)
             raise e
 
     def raw_execute(self,


### PR DESCRIPTION
We have decided to move away from Discord. We think that there
will be better community growth and adoption through slack.

## Changes

- Replaces discord links for slack.

## Testing

1. N/A

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

N/A
