### PR TITLE
Full parametrized decorator

### DIFF
--- a/decorators.md
+++ b/decorators.md
@@ -114,6 +114,22 @@ to make the parameterization decorators more consistent! But we will not break y
 
 *Note*: that the different input variables must all have compatible types with the original decorated input variable.
 
+## Migrating @parameterized
+
+As we've said above, we're planning on deprecating the following:
+
+- `@parameterized_inputs` (replaced by `@parameterize_inputs`)
+- `@parametrized` (replaced by `@parameterize_values`, as that's what its really doing)
+- `@parametrized_input` (gotten rid of in its original form, replaced by `@parameterize_inputs` as that is more versatile.)
+
+In other words, we're aligning around the following `@parameterize` implementations:
+
+- `@parameterize` -- this does everything you want
+- `@parameterize_values` -- this just changes the values, does not change the input source
+- `@parameterize_inputs`-- this just changes the source of the inputs
+
+The only non-drop-in change you'll have to do is for `@parameterized`. We won't update this until `hamilton==2.0.0`, though,
+so you'll have time.
 
 
 ## @extract_columns

--- a/decorators.md
+++ b/decorators.md
@@ -5,7 +5,7 @@ business-logic reuse. The decorators we've defined are as follows
 (source can be found in [function_modifiers](hamilton/function_modifiers.py)):
 
 ## @parameterize
-´xpands a signle function into n, each of which correspond to a function in which the parameter value is replaced either by:
+´Expands a single function into n, each of which correspond to a function in which the parameter value is replaced either by:
 1. A specific value
 2. An specific upstream node.
 
@@ -65,7 +65,9 @@ the arguments are pulled from outside the DAG. The _assigned_output_ key word ar
 tuple(Output Name, Documentation string) -> value.
 
 Note that `@parametrized` is deprecated, and we intend for you to use `@parameterize_vales`. We're consolidating
-to make the parameterization decorators more consistent! But we will not break your workflow for a long time.
+to make the parameterization decorators more consistent! You have plenty of time to migrate,
+we wont make this a hard change until we have a Hamilton 2.0.0 to release.
+
 
 ## @parameterize_inputs (replacing @parameterized_inputs)
 

--- a/decorators.md
+++ b/decorators.md
@@ -44,7 +44,7 @@ Expands a single function into n, each of which corresponds to a function in whi
 that *specific value*.
 ```python
 import pandas as pd
-from hamilton.function_modifiers import parametrized
+from hamilton.function_modifiers import parameterize_values
 import internal_package_with_logic
 
 ONE_OFF_DATES = {
@@ -53,7 +53,7 @@ ONE_OFF_DATES = {
     ('SOME_OUTPUT_NAME', 'Doc string for this thing'): 'value to pass to function',
 }
             # parameter matches the name of the argument in the function below
-@parametrized(parameter='one_off_date', assigned_output=ONE_OFF_DATES)
+@parameterize_values(parameter='one_off_date', assigned_output=ONE_OFF_DATES)
 def create_one_off_dates(date_index: pd.Series, one_off_date: str) -> pd.Series:
     """Given a date index, produces a series where a 1 is placed at the date index that would contain that event."""
     one_off_dates = internal_package_with_logic.get_business_week(one_off_date)
@@ -77,7 +77,7 @@ the input here is another DAG node(s), i.e. column/input, rather than a specific
 
 ```python
 import pandas as pd
-from hamilton.function_modifiers import parameterized_inputs
+from hamilton.function_modifiers import parameterize_inputs
 
 
 @parameterize_inputs(

--- a/graph_adapter_tests/h_dask/test_h_dask.py
+++ b/graph_adapter_tests/h_dask/test_h_dask.py
@@ -7,7 +7,7 @@ from distributed import Client
 from hamilton import driver
 from hamilton.experimental import h_dask
 
-from .resources import example_module
+from .resources import example_module, smoke_screen_module
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def client():
         yield client
 
 
-def test_dask_graph_adapter(client):
+def test_dask_graph_adapter_simple(client):
     initial_columns = {
         # NOTE: here you could load individual columns from a parquet file
         # in delayed manner, e.g., using sth. along the lines of
@@ -39,3 +39,23 @@ def test_dask_graph_adapter(client):
     expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
     pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
     # TODO: do some more asserting?
+
+
+def test_smoke_screen_module(client):
+    config = {'region': 'US'}
+    index = pd.Series(pd.DatetimeIndex(pd.date_range(start='20200101', end='20220801', freq='7d')))
+    dr = driver.Driver(config, smoke_screen_module, adapter=h_dask.DaskGraphAdapter(client))
+    output_columns = [
+        'raw_acquisition_cost',
+        'pessimistic_net_acquisition_cost',
+        'neutral_net_acquisition_cost',
+        'optimistic_net_acquisition_cost'
+    ]
+    df = dr.execute(
+        inputs={'start_date': '20200101', 'end_date': '20220801'},
+        final_vars=output_columns)
+    epsilon = 0.00001
+    assert abs(df.mean()['raw_acquisition_cost'] - 0.393808) < epsilon
+    assert abs(df.mean()['pessimistic_net_acquisition_cost'] - 0.420769) < epsilon
+    assert abs(df.mean()['neutral_net_acquisition_cost'] - 0.405582) < epsilon
+    assert abs(df.mean()['optimistic_net_acquisition_cost'] - 0.399363) < epsilon

--- a/graph_adapter_tests/h_ray/test_h_ray.py
+++ b/graph_adapter_tests/h_ray/test_h_ray.py
@@ -6,7 +6,7 @@ import ray
 from hamilton import driver, base
 from hamilton.experimental import h_ray
 
-from .resources import example_module
+from .resources import example_module, smoke_screen_module
 
 """
 For reference https://docs.ray.io/en/latest/auto_examples/testing-tips.html
@@ -37,3 +37,22 @@ def test_ray_graph_adapter(init):
     expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
     pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
     # TODO: do some more asserting?
+
+
+def test_smoke_screen_module(init):
+    config = {'region': 'US'}
+    dr = driver.Driver(config, smoke_screen_module, adapter=h_ray.RayGraphAdapter(base.PandasDataFrameResult()))
+    output_columns = [
+        'raw_acquisition_cost',
+        'pessimistic_net_acquisition_cost',
+        'neutral_net_acquisition_cost',
+        'optimistic_net_acquisition_cost'
+    ]
+    df = dr.execute(
+        inputs={'start_date': '20200101', 'end_date': '20220801'},
+        final_vars=output_columns)
+    epsilon = 0.00001
+    assert abs(df.mean()['raw_acquisition_cost'] - 0.393808) < epsilon
+    assert abs(df.mean()['pessimistic_net_acquisition_cost'] - 0.420769) < epsilon
+    assert abs(df.mean()['neutral_net_acquisition_cost'] - 0.405582) < epsilon
+    assert abs(df.mean()['optimistic_net_acquisition_cost'] - 0.399363) < epsilon

--- a/graph_adapter_tests/h_ray/test_h_ray_workflow.py
+++ b/graph_adapter_tests/h_ray/test_h_ray_workflow.py
@@ -9,7 +9,7 @@ from ray import workflow
 from hamilton import driver, base
 from hamilton.experimental import h_ray
 
-from graph_adapter_tests.h_ray.resources import example_module
+from graph_adapter_tests.h_ray.resources import example_module, smoke_screen_module
 
 
 @pytest.fixture(scope='module')
@@ -27,7 +27,7 @@ def test_ray_workflow_graph_adapter(init):
         'spend': pd.Series([10, 10, 20, 40, 40, 50]),
     }
     dr = driver.Driver(initial_columns, example_module,
-                       adapter=h_ray.RayWorkflowGraphAdapter(base.PandasDataFrameResult(), 'test-123'))
+                       adapter=h_ray.RayWorkflowGraphAdapter(base.PandasDataFrameResult(), 'test-test_ray_workflow_graph_adapter'))
     output_columns = [
         'spend',
         'signups',
@@ -39,3 +39,23 @@ def test_ray_workflow_graph_adapter(init):
     expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], name='avg_3wk_spend')
     pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0), expected_column)  # fill na to get around NaN
     # TODO: do some more asserting?
+
+
+def test_smoke_screen_module(init):
+    workflow.init()
+    config = {'region': 'US'}
+    dr = driver.Driver(config, smoke_screen_module, adapter=h_ray.RayWorkflowGraphAdapter(base.PandasDataFrameResult(), 'test-test_smoke_screen_module'))
+    output_columns = [
+        'raw_acquisition_cost',
+        'pessimistic_net_acquisition_cost',
+        'neutral_net_acquisition_cost',
+        'optimistic_net_acquisition_cost'
+    ]
+    df = dr.execute(
+        inputs={'start_date' : '20200101', 'end_date' : '20220801'},
+        final_vars=output_columns)
+    epsilon = 0.00001
+    assert abs(df.mean()['raw_acquisition_cost'] - 0.393808) < epsilon
+    assert abs(df.mean()['pessimistic_net_acquisition_cost'] - 0.420769) < epsilon
+    assert abs(df.mean()['neutral_net_acquisition_cost'] - 0.405582) < epsilon
+    assert abs(df.mean()['optimistic_net_acquisition_cost'] - 0.399363) < epsilon

--- a/graph_adapter_tests/h_spark/test_h_spark.py
+++ b/graph_adapter_tests/h_spark/test_h_spark.py
@@ -7,7 +7,7 @@ import pyspark.pandas as ps
 from hamilton import driver, base
 from hamilton.experimental import h_spark
 
-from .resources import example_module
+from .resources import example_module, smoke_screen_module
 
 
 @pytest.fixture(scope='module')
@@ -42,3 +42,31 @@ def test_koalas_spark_graph_adapter(spark_session):
     expected_column = pd.Series([0.0, 0.0, 13.33333, 23.33333, 33.33333, 43.33333], index=[0, 1, 2, 3, 4, 5], name='avg_3wk_spend')
     pd.testing.assert_series_equal(df.avg_3wk_spend.fillna(0.0).sort_index(), expected_column)  # fill na to get around NaN
     # TODO: do some more asserting?
+
+
+def test_smoke_screen_module(spark_session):
+    config = {'region': 'US', 'pandas_on_spark': True}
+    ps.set_option('compute.ops_on_diff_frames', True)  # we should play around here on how to correctly initialize data.
+    ps.set_option('compute.default_index_type', 'distributed')  # this one doesn't seem to work?
+    dr = driver.Driver(
+        config,
+        smoke_screen_module, adapter=h_spark.SparkKoalasGraphAdapter(
+            spark_session,
+            result_builder=base.PandasDataFrameResult(),
+            spine_column='weeks')
+    )
+    output_columns = [
+        'raw_acquisition_cost',
+        'pessimistic_net_acquisition_cost',
+        'neutral_net_acquisition_cost',
+        'optimistic_net_acquisition_cost',
+        'weeks'
+    ]
+    df = dr.execute(
+        inputs={'start_date': '20200101', 'end_date': '20220801'},
+        final_vars=output_columns)
+    epsilon = 0.00001
+    assert abs(df.mean()['raw_acquisition_cost'] - 0.393808) < epsilon
+    assert abs(df.mean()['pessimistic_net_acquisition_cost'] - 0.420769) < epsilon
+    assert abs(df.mean()['neutral_net_acquisition_cost'] - 0.405582) < epsilon
+    assert abs(df.mean()['optimistic_net_acquisition_cost'] - 0.399363) < epsilon

--- a/hamilton/dev_utils/deprecation.py
+++ b/hamilton/dev_utils/deprecation.py
@@ -1,0 +1,121 @@
+import dataclasses
+import functools
+import logging
+from typing import Callable, Optional, Union, Tuple
+
+from hamilton import version
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    def __gt__(self, other: 'Version'):
+        return (self.major, self.minor, self.patch) > (other.major, other.minor, other.patch)
+
+    @staticmethod
+    def current() -> 'Version':
+        current_version = version.VERSION
+        if len(current_version) > 3:  # This means we have an RC
+            current_version = current_version[0:3]  # Then let's ignore it
+        return Version(*current_version)  # TODO, add some validation
+
+    def __repr__(self):
+        return '.'.join(map(str, [self.major, self.minor, self.patch]))
+
+
+CURRENT_VERSION = Version.current()
+
+
+class DeprecationError(Exception):
+    def raise_(self):
+        raise self
+
+
+@dataclasses.dataclass
+class deprecated:
+    """Deprecation decorator -- use judiciously! For example:
+    @deprecate(
+        warn_starting=(1,10,0)
+        fail_starting=(2,0,0),
+        use_instead=parameterize_values,
+        reason='We have redefined the parameterization decorators to consist of `parametrize`, `parametrize_inputs`, and `parametrize_values`
+        migration_guide="https://github.com/stitchfix/hamilton/..."
+    )
+    class parameterized(...):
+       ...
+    Note this locks into a future contract (although it *can* be changed), so if you promise to deprecate something by X.0, then do it!
+
+    """
+    warn_starting: Union[Tuple[int, int, int], Version]
+    fail_starting: Union[Tuple[int, int, int], Version]
+    use_this: Optional[Callable]  # If this is None, it means this functionality is no longer supported.
+    explanation: str
+    migration_guide: Optional[str]  # If this is None, this means that the use_instead is a drop in replacement
+    current_version: Union[Tuple[int, int, int], Version] = dataclasses.field(default=CURRENT_VERSION)
+    warn_action: Callable[[str], None] = dataclasses.field(default=logger.warning)
+    fail_action: Callable[[str], None] = dataclasses.field(default=lambda message: DeprecationError(message).raise_())
+
+    @staticmethod
+    def _raise_failure(message: str):
+        raise DeprecationError(message)
+
+    @staticmethod
+    def ensure_version_type(version_spec: Union[Tuple[int, int, int], Version]) -> Version:
+        if isinstance(version_spec, tuple):
+            return Version(*version_spec)
+        return version_spec
+
+    def __post_init__(self):
+        if self.use_this is None:
+            if self.migration_guide is None:
+                raise ValueError('@deprecate must include a migration guide if there is no replacement.')
+        self.warn_starting = deprecated.ensure_version_type(self.warn_starting)
+        self.fail_starting = deprecated.ensure_version_type(self.fail_starting)
+        self.current_version = deprecated.ensure_version_type(self.current_version)
+        self._validate_fail_starting()
+
+    def _validate_fail_starting(self):
+        if self.fail_starting.major > 0:  # This means we're past alpha. We are, but nice to have...
+            if self.fail_starting.minor != 0 or self.fail_starting.patch != 0:
+                raise ValueError(f'Can only deprecate starting on major version releases. {self.fail_starting} is not valid.')
+        if self.warn_starting > self.fail_starting:
+            raise ValueError(f'warn_starting must come before fail_starting. {self.fail_starting} < {self.warn_starting}')
+
+    def _do_action(self, fn: Callable):
+        if self._should_fail():
+            failure_message = ' '.join(
+                [
+                    f'{fn.__qualname__} has been deprecated, as of hamilton version: {self.fail_starting}.',
+                    f'{self.explanation}'
+                ] + \
+                ([f'Instead, you should be using: {self.use_this.__qualname__}.'] if self.use_this is not None else []) + \
+                ([f'For migration, see: {self.migration_guide}.'] if self.migration_guide is not None else [f'This is a drop-in replacement.']))
+            self.fail_action(failure_message)
+        elif self._should_warn():
+            warn_message = ' '.join(
+                [
+                    f'{fn.__qualname__} will be deprecated by of hamilton version: {self.fail_starting}.',
+                    f'{self.explanation}'
+                ] + \
+                ([f'Instead, you should be using: {self.use_this.__qualname__}.'] if self.use_this is not None else []) + \
+                ([f'For migration, see: {self.migration_guide}.'] if self.migration_guide is not None else [f'This is a drop-in replacement.']))
+            self.warn_action(warn_message)
+
+    def _should_warn(self) -> bool:
+        return self.current_version > self.warn_starting
+
+    def _should_fail(self) -> bool:
+        return self.current_version > self.fail_starting
+
+    def __call__(self, fn: Callable):
+        @functools.wraps(fn)
+        def replacement(*args, **kwargs):
+            self._do_action(fn)
+            return fn(*args, **kwargs)
+
+        return replacement

--- a/hamilton/dev_utils/deprecation.py
+++ b/hamilton/dev_utils/deprecation.py
@@ -113,9 +113,5 @@ class deprecated:
         return self.current_version > self.fail_starting
 
     def __call__(self, fn: Callable):
-        @functools.wraps(fn)
-        def replacement(*args, **kwargs):
-            self._do_action(fn)
-            return fn(*args, **kwargs)
-
-        return replacement
+        self._do_action(fn)
+        return fn

--- a/hamilton/dev_utils/deprecation.py
+++ b/hamilton/dev_utils/deprecation.py
@@ -19,11 +19,16 @@ class Version:
         return (self.major, self.minor, self.patch) > (other.major, other.minor, other.patch)
 
     @staticmethod
+    def from_version_tuple(version_tuple: Tuple[Union[int, str], ...]) -> 'Version':
+        version_ = version_tuple
+        if len(version_) > 3:  # This means we have an RC
+            version_ = version_tuple[0:3]  # Then let's ignore it
+        return Version(*version_)  # TODO, add some validation
+
+    @staticmethod
     def current() -> 'Version':
         current_version = version.VERSION
-        if len(current_version) > 3:  # This means we have an RC
-            current_version = current_version[0:3]  # Then let's ignore it
-        return Version(*current_version)  # TODO, add some validation
+        return Version.from_version_tuple(current_version)
 
     def __repr__(self):
         return '.'.join(map(str, [self.major, self.minor, self.patch]))
@@ -140,6 +145,7 @@ class deprecated:
         def new__call__(self, *args, deprecator=self, fn=fn, **kwargs):
             deprecator._do_deprecation_action(fn)
             return fn.__old_call__(self, *args, **kwargs)
+
         # This works as we're assigning it to the entire class...
         # This also means we can't decorate it with 2 deprecation functions, but, hey,
         # its on you if you try to deprecate something twice

--- a/hamilton/experimental/h_ray.py
+++ b/hamilton/experimental/h_ray.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import typing
 
@@ -58,6 +59,8 @@ class RayGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         :param kwargs: the arguments that should be passed to it.
         :return: returns a ray object reference.
         """
+        if isinstance(node.callable, functools.partial):
+            return functools.partial(ray.remote(node.callable.func).remote, *node.callable.args, **node.callable.keywords)(**kwargs)
         return ray.remote(node.callable).remote(**kwargs)
 
     def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -79,13 +79,13 @@ def upstream(source: Any) -> UpstreamDependency:
     return UpstreamDependency(source=source)
 
 
-class parametrized_full(function_modifiers_base.NodeExpander):
+class parameterize(function_modifiers_base.NodeExpander):
     RESERVED_KWARG = 'output_name'
 
     # TODO -- make this take in just a parameter if we want to use the auto-generated docstring?
     def __init__(self, **parametrization: Union[Dict[str, ParametrizedDependency], Tuple[Dict[str, ParametrizedDependency], str]]):
-        """Creates a parametrized_full decorator. For example:
-            @parametrized_full(
+        """Creates a parameterize decorator. For example:
+            @parameterize(
                 replace_no_parameters=({}, 'fn with no parameters replaced'),
                 replace_just_upstream_parameter=({'upstream_parameter': upstream('foo_source')}, 'fn with upstream_parameter set to node foo'),
                 replace_just_literal_parameter=({'literal_parameter': literal('bar')}, 'fn with upstream_parameter set to node foo'),
@@ -105,7 +105,7 @@ class parametrized_full(function_modifiers_base.NodeExpander):
                 if not isinstance(value, ParametrizedDependency):
                     bad_values.append(value)
         if bad_values:
-            raise InvalidDecoratorException(f'@parametrized_full must specify a dependency type -- either upstream() or literal().'
+            raise InvalidDecoratorException(f'@parameterize must specify a dependency type -- either upstream() or literal().'
                              f'The following are not allowed: {bad_values}.')
         self.specified_docstrings = {key: value[1] for key, value in parametrization.items() if isinstance(value, tuple)}
 
@@ -172,7 +172,7 @@ class parametrized_full(function_modifiers_base.NodeExpander):
                 f'as a parameter it is reserved.')
         missing_parameters = set()
         for mapping in self.parametrization.values():
-            for param_to_replace in mapping :
+            for param_to_replace in mapping:
                 if param_to_replace not in func_param_names:
                     missing_parameters.add(param_to_replace)
         if missing_parameters:
@@ -209,7 +209,7 @@ class parametrized_full(function_modifiers_base.NodeExpander):
                 **{**upstream_dependencies, **literal_dependencies}))
 
 
-class parametrized(parametrized_full):
+class parametrized(parameterize):
     def __init__(self, parameter: str, assigned_output: Dict[Tuple[str, str], Any]):
         """Constructor for a modifier that expands a single function into n, each of which
         corresponds to a function in which the parameter value is replaced by that *specific value*.
@@ -225,7 +225,7 @@ class parametrized(parametrized_full):
         super(parametrized, self).__init__(**{output: ({parameter: literal(value)}, documentation) for (output, documentation), value in assigned_output.items()})
 
 
-class parametrized_input(parametrized_full):
+class parametrized_input(parameterize):
     def __init__(self, parameter: str, variable_inputs: Dict[str, Tuple[str, str]]):
         """Constructor for a modifier that expands a single function into n, each of which
         corresponds to the specified parameter replaced by a *specific input column*.
@@ -253,7 +253,7 @@ class parametrized_input(parametrized_full):
             **{output: ({parameter: upstream(value)}, documentation) for value, (output, documentation) in variable_inputs.items()})
 
 
-class parameterized_inputs(parametrized_full):
+class parameterized_inputs(parameterize):
     def __init__(self, **parameterization: Dict[str, Dict[str, str]]):
         """Constructor for a modifier that expands a single function into n, each of which corresponds to replacing
         some subset of the specified parameters with specific inputs.

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -243,7 +243,7 @@ class parameterize_values(parameterize):
     fail_starting=(2, 0, 0),
     use_this=parameterize_values,
     explanation='We now support three parametrize decorators. @parameterize, @parameterize_values, and @parameterize_inputs',
-    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md'
+    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md#migrating-parameterized'
 )
 class parametrized(parameterize_values):
     pass
@@ -283,7 +283,7 @@ class parameterize_inputs(parameterize):
     fail_starting=(2, 0, 0),
     use_this=parameterize_inputs,
     explanation='We now support three parametrize decorators. @parameterize, @parameterize_values, and @parameterize_inputs',
-    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md'
+    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md#migrating-parameterized'
 )
 class parametrized_input(parameterize):
     def __init__(self, parameter: str, variable_inputs: Dict[str, Tuple[str, str]]):
@@ -318,7 +318,7 @@ class parametrized_input(parameterize):
     fail_starting=(2, 0, 0),
     use_this=parameterize_inputs,
     explanation='We now support three parametrize decorators. @parameterize, @parameterize_values, and @parameterize_inputs',
-    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md'  # TODO -- add a migration guide
+    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md#migrating-parameterized'
 )
 class parameterized_inputs(parameterize_inputs):
     pass

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -239,7 +239,7 @@ class parameterize_values(parameterize):
     fail_starting=(2, 0, 0),
     use_this=parameterize_values,
     explanation='We now support three parametrize decorators. @parameterize, @parameterize_values, and @parameterize_inputs',
-    migration_guide='...'  # TODO -- add a migration guide
+    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md'
 )
 class parametrized(parameterize_values):
     pass
@@ -279,7 +279,7 @@ class parameterize_inputs(parameterize):
     fail_starting=(2, 0, 0),
     use_this=parameterize_inputs,
     explanation='We now support three parametrize decorators. @parameterize, @parameterize_values, and @parameterize_inputs',
-    migration_guide='...'  # TODO -- add a migration guide
+    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md'
 )
 class parametrized_input(parameterize):
     def __init__(self, parameter: str, variable_inputs: Dict[str, Tuple[str, str]]):
@@ -314,7 +314,7 @@ class parametrized_input(parameterize):
     fail_starting=(2, 0, 0),
     use_this=parameterize_inputs,
     explanation='We now support three parametrize decorators. @parameterize, @parameterize_values, and @parameterize_inputs',
-    migration_guide='...'  # TODO -- add a migration guide
+    migration_guide='https://github.com/stitchfix/hamilton/blob/main/decorators.md'  # TODO -- add a migration guide
 )
 class parameterized_inputs(parameterize_inputs):
     pass

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -70,20 +70,30 @@ class UpstreamDependency(ParametrizedDependency):
         return ParametrizedDependencySource.UPSTREAM
 
 
-# def is_literal(self) -> bool:
-
 def literal(value: Any) -> LiteralDependency:
+    """Specifies that a parameterized dependency comes from a "literal" source.
+    E.G. literal("foo") means that the value is actualy the value "foo"
+
+    @param value: Python literal value to use
+    @return: A LiteralDependency object -- a signifier to the internal framework of the dependency type
+    """
     return LiteralDependency(value=value)
 
 
 def upstream(source: Any) -> UpstreamDependency:
+    """Specifies that a parameterized dependency comes from an "upstream" source.
+    This means that it comes from a node somewhere else.
+    E.G. upstream("foo") means that it should be assigned the value that "foo" outputs.
+
+    @param source: Upstream node to come from
+    @return:An UpstreamDependency object -- a signifier to the internal framework of the dependency type.
+    """
     return UpstreamDependency(source=source)
 
 
 class parameterize(function_modifiers_base.NodeExpander):
     RESERVED_KWARG = 'output_name'
 
-    # TODO -- make this take in just a parameter if we want to use the auto-generated docstring?
     def __init__(self, **parametrization: Union[Dict[str, ParametrizedDependency], Tuple[Dict[str, ParametrizedDependency], str]]):
         """Creates a parameterize decorator. For example:
             @parameterize(
@@ -124,9 +134,6 @@ class parameterize(function_modifiers_base.NodeExpander):
             literal_dependencies = {
                 parameter: replacement for parameter, replacement in parametrization.items()
                 if replacement.get_dependency_type() == ParametrizedDependencySource.LITERAL}
-
-            # Should we have a `literal` node/dependency type? Might be nicer than this -- E.G. we can see the inputs...
-            # Or we can create actual nodes that are just literals
 
             def replacement_function(*args, upstream_dependencies=upstream_dependencies, literal_dependencies=literal_dependencies, **kwargs):
                 """This function rewrites what is passed in kwargs to the right kwarg for the function."""

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -77,6 +77,8 @@ def literal(value: Any) -> LiteralDependency:
     @param value: Python literal value to use
     @return: A LiteralDependency object -- a signifier to the internal framework of the dependency type
     """
+    if isinstance(value, LiteralDependency):
+        return value
     return LiteralDependency(value=value)
 
 
@@ -88,6 +90,8 @@ def upstream(source: Any) -> UpstreamDependency:
     @param source: Upstream node to come from
     @return:An UpstreamDependency object -- a signifier to the internal framework of the dependency type.
     """
+    if isinstance(source, UpstreamDependency):
+        return source
     return UpstreamDependency(source=source)
 
 

--- a/hamilton/node.py
+++ b/hamilton/node.py
@@ -84,7 +84,6 @@ class Node(object):
             if input_types is not None:
                 raise ValueError(f'Input types cannot be provided for user-defined node {self.name}')
 
-
     @property
     def documentation(self) -> str:
         return self._doc

--- a/tests/resources/layered_decorators.py
+++ b/tests/resources/layered_decorators.py
@@ -1,4 +1,4 @@
-from hamilton.function_modifiers import config, does, parametrized, tag
+from hamilton.function_modifiers import config, does, parameterize_values
 
 """Demonstrates a DAG with multiple decorators for functions.
 This is a good test case to ensure that all the decorators work together
@@ -12,7 +12,7 @@ def _sum(**kwargs: int) -> int:
 
 
 @does(_sum)
-@parametrized(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'Second value'): 20})
+@parameterize_values(parameter='a', assigned_output={('e', 'First value'): 10, ('f', 'Second value'): 20})
 @config.when(foo='bar')
 def c__foobar(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.
@@ -25,7 +25,7 @@ def c__foobar(a: int, b: int) -> int:
 
 
 @does(_sum)
-@parametrized(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'Second value'): 22})
+@parameterize_values(parameter='a', assigned_output={('e', 'First value'): 11, ('f', 'Second value'): 22})
 @config.when(foo='baz')
 def c__foobaz(a: int, b: int) -> int:
     """Demonstrates utilizing a bunch of decorators.

--- a/tests/resources/parametrized_inputs.py
+++ b/tests/resources/parametrized_inputs.py
@@ -1,4 +1,4 @@
-from hamilton.function_modifiers import parametrized_input, parameterized_inputs
+from hamilton.function_modifiers import parametrized_input, parameterize_inputs
 
 
 def input_1() -> int:
@@ -25,7 +25,7 @@ def function_with_multiple_inputs(input_value_tbd: int, static_value: int) -> in
 
 
 # We don't prefer this style of specifying the values. i.e. kwarg with {}.
-@parameterized_inputs(
+@parameterize_inputs(
     output_12={'input_value_tbd1': 'input_1', 'input_value_tbd2': 'input_2'}
 )
 def function_with_two_parameters(input_value_tbd1: int,
@@ -39,7 +39,7 @@ def function_with_two_parameters(input_value_tbd1: int,
 
 
 # We prefer this style of specifying the values. i.e. kwarg with dict().
-@parameterized_inputs(
+@parameterize_inputs(
     output_123=dict(input_value_tbd1='input_1',
                     input_value_tbd2='input_2',
                     input_value_tbd3='input_3')

--- a/tests/resources/parametrized_inputs.py
+++ b/tests/resources/parametrized_inputs.py
@@ -1,4 +1,4 @@
-from hamilton.function_modifiers import parametrized_input, parameterize_inputs
+from hamilton.function_modifiers import parametrized_input, parameterize_sources
 
 
 def input_1() -> int:
@@ -25,7 +25,7 @@ def function_with_multiple_inputs(input_value_tbd: int, static_value: int) -> in
 
 
 # We don't prefer this style of specifying the values. i.e. kwarg with {}.
-@parameterize_inputs(
+@parameterize_sources(
     output_12={'input_value_tbd1': 'input_1', 'input_value_tbd2': 'input_2'}
 )
 def function_with_two_parameters(input_value_tbd1: int,
@@ -39,7 +39,7 @@ def function_with_two_parameters(input_value_tbd1: int,
 
 
 # We prefer this style of specifying the values. i.e. kwarg with dict().
-@parameterize_inputs(
+@parameterize_sources(
     output_123=dict(input_value_tbd1='input_1',
                     input_value_tbd2='input_2',
                     input_value_tbd3='input_3')

--- a/tests/resources/parametrized_nodes.py
+++ b/tests/resources/parametrized_nodes.py
@@ -1,7 +1,7 @@
-from hamilton.function_modifiers import parametrized
+from hamilton.function_modifiers import parameterize_values
 
 
-@parametrized('param', {('parametrized_1', 'doc'): 1, ('parametrized_2', 'doc'): 2, ('parametrized_3', 'doc'): 3})
+@parameterize_values('param', {('parametrized_1', 'doc'): 1, ('parametrized_2', 'doc'): 2, ('parametrized_3', 'doc'): 3})
 def to_parametrize(param: int) -> int:
     """Function that should be parametrized to form multiple functions"""
     return param

--- a/tests/resources/smoke_screen_module.py
+++ b/tests/resources/smoke_screen_module.py
@@ -1,0 +1,110 @@
+"""A module that has a bunch of features.
+This enables us to test out all capabilities in a smoke test, which is
+especially helpful for adding complex graphadapters.
+This aims to include the following features:
+
+1. @config.when() ✅
+2. @parameterize (arguments for both value and source) ✅
+3. @extract_columns ✅
+4. @extract_fields  ✅
+5. @does ✅
+6. @tag ✅
+7. @check_output (with default args) ✅
+
+Note this will also have a simple API to work with:
+
+1. Required inputs = start_date/end_date, 'YYYYMMDD'
+2. Required config = {'region' : 'US'/'CA'}
+3. Four outputs, all pd.Series:
+    raw_acquisition_cost
+    pessimistic_net_acquisition_cost
+    neutral_net_acquisition_cost
+    optimistic_net_acquisition_cost
+"""
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from hamilton.function_modifiers import source, value, config, extract_fields, does, extract_columns, parameterize, tag, check_output
+
+
+def _identity(**kwargs: int) -> int:
+    """The API for this is suboptimal but this will serve for testing."""
+    return list(kwargs.values())[0]
+
+
+@extract_fields(fields={'us_churn': int, 'ca_churn': dict})
+def weekly_churn() -> Dict[str, int]:
+    """Weekly churn for both regions. A little contrived so we can use extract_fields"""
+    return {
+        'us_churn': 3,
+        'ca_churn': 2
+    }
+
+
+@config.when(region='US')
+@does(_identity)
+def weekly_churn_base_rate__US(us_churn: int) -> int:
+    pass
+
+
+@config.when(region='CA')
+@does(_identity)
+def weekly_churn_base_rate__CA(ca_churn: int) -> int:
+    pass
+
+
+@config.when_not(pandas_on_spark=True)
+@extract_columns('spend', 'signups', 'weeks')
+def spend_and_signups_source__pd(start_date: str, end_date: str) -> pd.DataFrame:
+    """Yields `spend`, `signups`, and 'weeks' (the spine) in a single dataframe.
+    All of this is obviously dummy data.
+    """
+    index = pd.DatetimeIndex(pd.date_range(start=start_date, end=end_date, freq='7d'))
+    df_out = pd.DataFrame(
+        data=dict(
+            weeks=index,
+            counts=list(range(len(index))))
+    )
+    df_out['spend'] = df_out.apply(lambda row: 100 + min((row.counts + 1) * 5, 250), axis=1)
+    df_out['signups'] = df_out.apply(lambda row: 20 * min(row.counts + 1, 100), axis=1)
+    return df_out[['spend', 'signups', 'weeks']]
+
+
+@config.when(pandas_on_spark=True)
+@extract_columns('spend', 'signups', 'weeks')
+def spend_and_signups_source__ps(start_date: str, end_date: str) -> pd.DataFrame:
+    """Yields `spend`, `signups`, and 'weeks' (the spine) in a single dataframe.
+    All of this is obviously dummy data.
+    """
+    # This is just me being lazy -- need to dig into pandas on spark to figure out the best way to instantiate it
+    # But for now I can just re-use the code above.
+    pd_df = spend_and_signups_source__pd(start_date=start_date, end_date=end_date)
+    import pyspark.pandas as ps
+    return ps.DataFrame(pd_df)
+
+
+@check_output(
+    importance='fail',
+    range=(-1000, 10000),  # Could be negative but never below 100
+    data_type=np.float64
+)
+@parameterize(
+    net_signups_pessimistic={'optimism_adjustment': value(.5)},
+    net_signups_neutral={'optimism_adjustment': value(1.0)},
+    net_signups_optimistic={'optimism_adjustment': value(2)}
+)
+def net_signups(signups: pd.Series, weekly_churn_base_rate: int, optimism_adjustment: float) -> pd.Series:
+    return signups - weekly_churn_base_rate * 1 / optimism_adjustment
+
+
+@parameterize(
+    raw_acquisition_cost={'signups_source': source('signups')},
+    pessimistic_net_acquisition_cost={'signups_source': source('net_signups_pessimistic')},
+    neutral_net_acquisition_cost={'signups_source': source('net_signups_neutral')},
+    optimistic_net_acquisition_cost={'signups_source': source('net_signups_optimistic')},
+)
+@tag(final_output='true')
+def acquisition_cost(signups_source: pd.Series, spend: pd.Series) -> pd.Series:
+    return spend / signups_source

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -18,6 +18,16 @@ from hamilton.dev_utils.deprecation import Version, deprecated, DeprecationError
 def test_version_compare(version_1, version_2, op):
     assert op(version_1, version_2)
 
+@pytest.mark.parametrize(
+    'version_tuple,version',
+    [
+        ((0, 1, 2), Version(0,1,2)),
+        ((0, 1, 2, 'rc1'), Version(0,1,2))
+    ]
+)
+def test_from_version_tuple(version_tuple, version):
+    assert Version.from_version_tuple(version_tuple) == version
+
 
 @pytest.mark.parametrize(
     'kwargs',

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -71,7 +71,7 @@ def test_call_function_not_deprecated_yet():
     )
     def deprecated_function() -> bool:
         return False
-
+    deprecated_function()
     assert not warned
 
 
@@ -96,7 +96,7 @@ def test_call_function_soon_to_be_deprecated():
     )
     def deprecated_function() -> bool:
         return False
-
+    deprecated_function()
     assert warned
 
 
@@ -104,14 +104,89 @@ def test_call_function_already_deprecated():
     def replacement_function() -> bool:
         return True
 
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(1, 1, 0),
+    )
+    def deprecated_function():
+        return False
+
     with pytest.raises(DeprecationError):
-        @deprecated(
-            warn_starting=(0, 5, 0),
-            fail_starting=(1, 0, 0),
-            use_this=replacement_function,
-            explanation='True is the new False',
-            migration_guide='https://github.com/stitchfix/hamilton',
-            current_version=(1, 1, 0),
-        )
-        def deprecated_function() -> bool:
+        deprecated_function()
+
+
+def test_call_function_class_not_deprecated_yet():
+    warned = False
+
+    def warn(s):
+        nonlocal warned
+        warned = True
+
+    def replacement_function() -> bool:
+        return True
+
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(0, 0, 0),
+        warn_action=warn
+    )
+    class deprecated_function:
+        def __call__(self):
             return False
+
+    deprecated_function()
+    assert not warned
+
+
+def test_call_function_class_soon_to_be_deprecated():
+    warned = False
+
+    def warn(s):
+        nonlocal warned
+        warned = True
+
+    def replacement_function() -> bool:
+        return True
+
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(0, 6, 0),
+        warn_action=warn
+    )
+    class deprecated_function:
+        def __call__(self):
+            return False
+    deprecated_function()()
+    assert warned
+
+
+def test_call_function_class_already_deprecated():
+    def replacement_function() -> bool:
+        return True
+
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(1, 1, 0),
+    )
+    class deprecated_function:
+        def __call__(self):
+            return False
+
+    with pytest.raises(DeprecationError):
+        deprecated_function()()

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -72,7 +72,6 @@ def test_call_function_not_deprecated_yet():
     def deprecated_function() -> bool:
         return False
 
-    deprecated_function()
     assert not warned
 
 
@@ -98,7 +97,6 @@ def test_call_function_soon_to_be_deprecated():
     def deprecated_function() -> bool:
         return False
 
-    deprecated_function()
     assert warned
 
 
@@ -106,16 +104,14 @@ def test_call_function_already_deprecated():
     def replacement_function() -> bool:
         return True
 
-    @deprecated(
-        warn_starting=(0, 5, 0),
-        fail_starting=(1, 0, 0),
-        use_this=replacement_function,
-        explanation='True is the new False',
-        migration_guide='https://github.com/stitchfix/hamilton',
-        current_version=(1, 1, 0),
-    )
-    def deprecated_function() -> bool:
-        return False
-
     with pytest.raises(DeprecationError):
-        deprecated_function()
+        @deprecated(
+            warn_starting=(0, 5, 0),
+            fail_starting=(1, 0, 0),
+            use_this=replacement_function,
+            explanation='True is the new False',
+            migration_guide='https://github.com/stitchfix/hamilton',
+            current_version=(1, 1, 0),
+        )
+        def deprecated_function() -> bool:
+            return False

--- a/tests/test_dev_utils.py
+++ b/tests/test_dev_utils.py
@@ -1,0 +1,121 @@
+import operator
+
+import pytest
+
+from hamilton.dev_utils.deprecation import Version, deprecated, DeprecationError
+
+
+@pytest.mark.parametrize(
+    'version_1, version_2, op',
+    [
+        (Version(0, 1, 2), Version(0, 1, 2), operator.eq),
+        (Version(0, 1, 2), Version(0, 1, 3), operator.lt),
+        (Version(0, 1, 2), Version(0, 1, 1), operator.gt),
+        (Version(1, 9, 0), Version(2, 0, 0), operator.lt),
+        (Version(2, 0, 0), Version(1, 9, 0), operator.gt),
+    ]
+)
+def test_version_compare(version_1, version_2, op):
+    assert op(version_1, version_2)
+
+
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        dict(warn_starting=(0, 0, 0), fail_starting=(0, 0, 1), use_this=None,
+             explanation='something', migration_guide='https://github.com/stitchfix/hamilton'),
+        dict(warn_starting=(0, 0, 0), fail_starting=(0, 0, 1), use_this=test_version_compare,
+             explanation='something', migration_guide=None),
+        dict(warn_starting=(0, 0, 0), fail_starting=(1, 0, 0), use_this=test_version_compare,
+             explanation='something', migration_guide=None)
+    ]
+)
+def test_validate_deprecated_decorator_params_happy(kwargs):
+    deprecated(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        dict(warn_starting=(1, 0, 0), fail_starting=(0, 0, 1), use_this=None,
+             explanation='something', migration_guide='https://github.com/stitchfix/hamilton'),
+        dict(warn_starting=(0, 0, 0), fail_starting=(0, 0, 1), use_this=None,
+             explanation='something', migration_guide=None),
+        dict(warn_starting=(0, 0, 0), fail_starting=(1, 0, 0), use_this=None,
+             explanation='something', migration_guide=None)
+    ]
+)
+def test_validate_deprecated_decorator_params_sad(kwargs):
+    with pytest.raises(ValueError):
+        deprecated(**kwargs)
+
+
+def test_call_function_not_deprecated_yet():
+    warned = False
+
+    def warn(s):
+        nonlocal warned
+        warned = True
+
+    def replacement_function() -> bool:
+        return True
+
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(0, 0, 0),
+        warn_action=warn
+    )
+    def deprecated_function() -> bool:
+        return False
+
+    deprecated_function()
+    assert not warned
+
+
+def test_call_function_soon_to_be_deprecated():
+    warned = False
+
+    def warn(s):
+        nonlocal warned
+        warned = True
+
+    def replacement_function() -> bool:
+        return True
+
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(0, 6, 0),
+        warn_action=warn
+    )
+    def deprecated_function() -> bool:
+        return False
+
+    deprecated_function()
+    assert warned
+
+
+def test_call_function_already_deprecated():
+    def replacement_function() -> bool:
+        return True
+
+    @deprecated(
+        warn_starting=(0, 5, 0),
+        fail_starting=(1, 0, 0),
+        use_this=replacement_function,
+        explanation='True is the new False',
+        migration_guide='https://github.com/stitchfix/hamilton',
+        current_version=(1, 1, 0),
+    )
+    def deprecated_function() -> bool:
+        return False
+
+    with pytest.raises(DeprecationError):
+        deprecated_function()

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -741,7 +741,7 @@ def concat(upstream_parameter: str, literal_parameter: str) -> Any:
 
 
 def test_parametrized_full_no_replacement():
-    annotation = function_modifiers.parametrized_full(replace_no_parameters={})
+    annotation = function_modifiers.parameterize(replace_no_parameters={})
     node_, = annotation.expand_node(node.Node.from_fn(concat), {}, concat)
     assert node_.callable(upstream_parameter='foo', literal_parameter='bar') == 'foobar'
     assert node_.input_types == {'literal_parameter': (str, DependencyType.REQUIRED), 'upstream_parameter': (str, DependencyType.REQUIRED)}
@@ -749,7 +749,7 @@ def test_parametrized_full_no_replacement():
 
 
 def test_parametrized_full_replace_just_upstream():
-    annotation = function_modifiers.parametrized_full(
+    annotation = function_modifiers.parameterize(
         replace_just_upstream_parameter={'upstream_parameter': upstream('foo_source')},
     )
     node_, = annotation.expand_node(node.Node.from_fn(concat), {}, concat)
@@ -761,7 +761,7 @@ def test_parametrized_full_replace_just_upstream():
 
 
 def test_parametrized_full_replace_just_literal():
-    annotation = function_modifiers.parametrized_full(replace_just_literal_parameter={'literal_parameter': literal('bar')})
+    annotation = function_modifiers.parameterize(replace_just_literal_parameter={'literal_parameter': literal('bar')})
     node_, = annotation.expand_node(node.Node.from_fn(concat), {}, concat)
     assert node_.input_types == {'upstream_parameter': (str, DependencyType.REQUIRED)}
     assert node_.callable(upstream_parameter='foo') == 'foobar'
@@ -769,7 +769,7 @@ def test_parametrized_full_replace_just_literal():
 
 
 def test_parametrized_full_replace_both():
-    annotation = function_modifiers.parametrized_full(
+    annotation = function_modifiers.parameterize(
         replace_both_parameters={'upstream_parameter': upstream('foo_source'), 'literal_parameter': literal('bar')}
     )
     node_, = annotation.expand_node(node.Node.from_fn(concat), {}, concat)
@@ -785,7 +785,7 @@ def test_parametrized_full_multiple_replacements():
         replace_just_literal_parameter=({'literal_parameter': literal('bar')}, 'fn with upstream_parameter set to node foo'),
         replace_both_parameters=({'upstream_parameter': upstream('foo_source'), 'literal_parameter': literal('bar')}, 'fn with both parameters replaced')
     )
-    annotation = function_modifiers.parametrized_full(**args)
+    annotation = function_modifiers.parameterize(**args)
     nodes = annotation.expand_node(node.Node.from_fn(concat), {}, concat)
     assert len(nodes) == 4
     # test out that documentation is assigned correctly

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -13,7 +13,7 @@ from tests.resources.dq_dummy_examples import DUMMY_VALIDATORS_FOR_TESTING, Samp
 
 
 def test_parametrized_invalid_params():
-    annotation = function_modifiers.parametrized(
+    annotation = function_modifiers.parameterize_values(
         parameter='non_existant',
         assigned_output={('invalid_node_name', 'invalid_doc'): 'invalid_value'}
     )
@@ -33,14 +33,14 @@ def test_parametrized_invalid_params():
 
 def test_parametrized_single_param_breaks_without_docs():
     with pytest.raises(function_modifiers.InvalidDecoratorException):
-        function_modifiers.parametrized(
+        function_modifiers.parameterize_values(
             parameter='parameter',
             assigned_output={'only_node_name': 'only_value'}
         )
 
 
 def test_parametrized_single_param():
-    annotation = function_modifiers.parametrized(
+    annotation = function_modifiers.parameterize_values(
         parameter='parameter',
         assigned_output={('only_node_name', 'only_doc'): 'only_value'}
     )
@@ -58,7 +58,7 @@ def test_parametrized_single_param():
 
 
 def test_parametrized_single_param_expanded():
-    annotation = function_modifiers.parametrized(
+    annotation = function_modifiers.parameterize_values(
         parameter='parameter',
         assigned_output={
             ('node_name_1', 'doc1'): 'value_1',
@@ -78,7 +78,7 @@ def test_parametrized_single_param_expanded():
 
 
 def test_parametrized_with_multiple_params():
-    annotation = function_modifiers.parametrized(
+    annotation = function_modifiers.parameterize_values(
         parameter='parameter',
         assigned_output={
             ('node_name_1', 'doc1'): 'value_1',
@@ -115,8 +115,8 @@ def test_parametrized_input():
 
 
 def test_parametrized_inputs_validate_param_name():
-    """Tests validate function of parameterized_inputs capturing bad param name usage."""
-    annotation = function_modifiers.parameterized_inputs(
+    """Tests validate function of parameterize_inputs capturing bad param name usage."""
+    annotation = function_modifiers.parameterize_inputs(
         parameterization={
             'test_1': dict(parameterfoo='input_1'),
         })
@@ -130,8 +130,8 @@ def test_parametrized_inputs_validate_param_name():
 
 
 def test_parametrized_inputs_validate_reserved_param():
-    """Tests validate function of parameterized_inputs catching reserved param usage."""
-    annotation = function_modifiers.parameterized_inputs(
+    """Tests validate function of parameterize_inputs catching reserved param usage."""
+    annotation = function_modifiers.parameterize_inputs(
         **{
             'test_1': dict(parameter2='input_1'),
         })
@@ -145,8 +145,8 @@ def test_parametrized_inputs_validate_reserved_param():
 
 
 def test_parametrized_inputs_validate_bad_doc_string():
-    """Tests validate function of parameterized_inputs catching bad doc string."""
-    annotation = function_modifiers.parameterized_inputs(
+    """Tests validate function of parameterize_inputs catching bad doc string."""
+    annotation = function_modifiers.parameterize_inputs(
         **{
             'test_1': dict(parameter2='input_1'),
         })
@@ -160,7 +160,7 @@ def test_parametrized_inputs_validate_bad_doc_string():
 
 
 def test_parametrized_inputs():
-    annotation = function_modifiers.parameterized_inputs(
+    annotation = function_modifiers.parameterize_inputs(
         **{
             'test_1': dict(parameter1='input_1', parameter2='input_2'),
             'test_2': dict(parameter1='input_2', parameter2='input_1'),

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -798,5 +798,5 @@ def test_parametrized_full_multiple_replacements():
         f'3. Replace the other variants with this, ensure all use-cases are covered \n ✅'
         f'4. Refactor to fix weird polymorphism or simplify in another way\n'
         f'5. Refactor all decorators to be in a `function_modifiers` module if possible. Then have the __init__.py just copy them\n'
-        f'6. Add a @deprecate meta-decorator for deprecating decorators\n'
+        f'6. Add a @deprecate meta-decorator for deprecating decorators\n ✅'
     )

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -7,7 +7,7 @@ import pytest
 from hamilton import function_modifiers, models, function_modifiers_base
 from hamilton import node
 from hamilton.data_quality.base import ValidationResult, DataValidationError
-from hamilton.function_modifiers import does, ensure_function_empty, check_output, check_output_custom, IS_DATA_VALIDATOR_TAG, DATA_VALIDATOR_ORIGINAL_OUTPUT_TAG, upstream, literal
+from hamilton.function_modifiers import does, ensure_function_empty, check_output, check_output_custom, IS_DATA_VALIDATOR_TAG, DATA_VALIDATOR_ORIGINAL_OUTPUT_TAG, upstream, literal, LiteralDependency, UpstreamDependency
 from hamilton.node import DependencyType
 from tests.resources.dq_dummy_examples import DUMMY_VALIDATORS_FOR_TESTING, SampleDataValidator2, SampleDataValidator3
 
@@ -790,3 +790,26 @@ def test_parametrized_full_multiple_replacements():
     assert len(nodes) == 4
     # test out that documentation is assigned correctly
     assert [node_.documentation for node_ in nodes] == [args[node_.name][1] for node_ in nodes]
+
+
+@pytest.mark.parametrize(
+    'source,expected',
+    [
+        ('foo', UpstreamDependency('foo')),
+        (UpstreamDependency('bar'), UpstreamDependency('bar'))
+    ]
+)
+def test_upstream(source, expected):
+    assert upstream(source) == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        ('foo', LiteralDependency('foo')),
+        (LiteralDependency('foo'), LiteralDependency('foo')),
+        (1, LiteralDependency(1))
+    ]
+)
+def test_literal(value, expected):
+    assert literal(value) == expected

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -790,13 +790,3 @@ def test_parametrized_full_multiple_replacements():
     assert len(nodes) == 4
     # test out that documentation is assigned correctly
     assert [node_.documentation for node_ in nodes] == [args[node_.name][1] for node_ in nodes]
-    raise Exception(
-        f'TODO next: \n'
-        f'1. Add tests to ensure this works ✅ \n'
-        f'2. Get it to work without supplying docstrings and instead using parametrization ✅ \n'
-        f'2.5 Figure out what the API should look like if parameters are not supplied -- likely keep it so it can work without that ✅ \n'
-        f'3. Replace the other variants with this, ensure all use-cases are covered \n ✅'
-        f'4. Refactor to fix weird polymorphism or simplify in another way\n'
-        f'5. Refactor all decorators to be in a `function_modifiers` module if possible. Then have the __init__.py just copy them\n'
-        f'6. Add a @deprecate meta-decorator for deprecating decorators\n ✅'
-    )

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -795,7 +795,8 @@ def test_parametrized_full_multiple_replacements():
         f'1. Add tests to ensure this works ✅ \n'
         f'2. Get it to work without supplying docstrings and instead using parametrization ✅ \n'
         f'2.5 Figure out what the API should look like if parameters are not supplied -- likely keep it so it can work without that ✅ \n'
-        f'3. Replace the other variants with this, ensure all use-cases are covered \n'
+        f'3. Replace the other variants with this, ensure all use-cases are covered \n ✅'
         f'4. Refactor to fix weird polymorphism or simplify in another way\n'
-        f'5. Refactor all decorators to be in a `function_modifiers` module if possible'
+        f'5. Refactor all decorators to be in a `function_modifiers` module if possible. Then have the __init__.py just copy them\n'
+        f'6. Add a @deprecate meta-decorator for deprecating decorators\n'
     )


### PR DESCRIPTION
Consolidates logic behind all `parametrized` decorators

## Changes

- adds `full_parametrized` decorator
- changes others to use it
- Adds a smoke_screen_test with a common set of decorators that we use
- Adds more testing for distributed integrations

## Testing

1.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
