### PR TITLE
Fixes DAG construction slowness

### DIFF
--- a/hamilton/function_modifiers_base.py
+++ b/hamilton/function_modifiers_base.py
@@ -190,9 +190,11 @@ class NodeTransformer(SubDAGModifier):
 
         def node_tagged_non_final(node_: node.Node):
             return node_.tags.get(NodeTransformer.NON_FINAL_TAG, False)  # Defaults to final
-
-        non_final_nodes = set(
-            sum([[dep for dep in node_.input_types] for node_ in nodes], [node_.name for node_ in nodes if node_tagged_non_final(node_)]))
+        non_final_nodes = set()
+        for node_ in nodes:
+            for dep in node_.input_types:
+                if not node_tagged_non_final(node_):
+                    non_final_nodes.add(dep)
         return [node_ for node_ in nodes if node_.name in non_final_nodes], [node_ for node_ in nodes if node_.name not in non_final_nodes]
 
     def transform_dag(self, nodes: Collection[node.Node], config: Dict[str, Any], fn: Callable) -> Collection[node.Node]:


### PR DESCRIPTION
This is an issue with check_output. We were using sum(lists) which does
a concat operation for each list. This is fine at a small scale, but at
a larger scale this is an O(n^2) operation. We can still optimize this
significantly but this fixes the underlying issue in #168.

Note that this does *not* fix the issues around ray yet, this is just
the underlying piece. With Ray, the hard part is validating everything
which is inherently slow. Worth looking into why parallelism didn't help
though.

[Short description explaining the high-level reason for the pull request]

## Changes

-

## Testing

1.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
