### PR TITLE
[ci] remove unnecessary f-strings

### DIFF
--- a/hamilton/data_quality/default_validators.py
+++ b/hamilton/data_quality/default_validators.py
@@ -221,7 +221,7 @@ class MaxFractionNansValidatorPandasSeries(base.BaseDefaultValidator):
     @staticmethod
     def _validate_max_fraction_nans(max_fraction_nans: float):
         if not (0 <= max_fraction_nans <= 1):
-            raise ValueError(f"Maximum fraction allowed to be nan must be in range [0,1]")
+            raise ValueError("Maximum fraction allowed to be nan must be in range [0,1]")
 
 
 class AllowNaNsValidatorPandasSeries(MaxFractionNansValidatorPandasSeries):
@@ -415,7 +415,7 @@ def _append_pandera_to_default_validators():
         import pandera
     except ModuleNotFoundError:
         logger.info(
-            f"Cannot import pandera from pandera_validators. Run pip install sf-hamilton[pandera] if needed."
+            "Cannot import pandera from pandera_validators. Run pip install sf-hamilton[pandera] if needed."
         )
         return
     from hamilton.data_quality import pandera_validators

--- a/hamilton/data_quality/pandera_validators.py
+++ b/hamilton/data_quality/pandera_validators.py
@@ -20,7 +20,7 @@ class PanderaDataFrameValidator(base.BaseDefaultValidator):
         )  # TODO -- allow for modin, etc. as they come for free with pandera
 
     def description(self) -> str:
-        return f"Validates that the returned dataframe matches the pander"
+        return "Validates that the returned dataframe matches the pander"
 
     def validate(self, data: pd.DataFrame) -> base.ValidationResult:
         try:

--- a/hamilton/dev_utils/deprecation.py
+++ b/hamilton/dev_utils/deprecation.py
@@ -122,7 +122,7 @@ class deprecated:
                 + (
                     [f"For migration, see: {self.migration_guide}."]
                     if self.migration_guide is not None
-                    else [f"This is a drop-in replacement."]
+                    else ["This is a drop-in replacement."]
                 )
             )
             self.fail_action(failure_message)
@@ -140,7 +140,7 @@ class deprecated:
                 + (
                     [f"For migration, see: {self.migration_guide}."]
                     if self.migration_guide is not None
-                    else [f"This is a drop-in replacement."]
+                    else ["This is a drop-in replacement."]
                 )
             )
             self.warn_action(warn_message)

--- a/hamilton/experimental/h_async.py
+++ b/hamilton/experimental/h_async.py
@@ -111,8 +111,8 @@ class AsyncDriver(driver.Driver):
         self.graph.execute(nodes, memoized_computation, overrides, inputs)
         if display_graph:
             raise ValueError(
-                f"display_graph=True is not supported for the async graph adapter. "
-                f"Instead you should be using visualize_execution."
+                "display_graph=True is not supported for the async graph adapter. "
+                "Instead you should be using visualize_execution."
             )
         task_dict = {
             key: asyncio.create_task(process_value(memoized_computation[key])) for key in final_vars
@@ -138,8 +138,8 @@ class AsyncDriver(driver.Driver):
         """
         if display_graph:
             raise ValueError(
-                f"display_graph=True is not supported for the async graph adapter. "
-                f"Instead you should be using visualize_execution."
+                "display_graph=True is not supported for the async graph adapter. "
+                "Instead you should be using visualize_execution."
             )
         try:
             outputs = await self.raw_execute(final_vars, overrides, display_graph, inputs=inputs)

--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -320,7 +320,7 @@ class parameterize_sources(parameterize):
         """
         self.parametrization = parameterization
         if not parameterization:
-            raise ValueError(f"Cannot pass empty/None dictionary to parameterize_sources")
+            raise ValueError("Cannot pass empty/None dictionary to parameterize_sources")
         for output, mappings in parameterization.items():
             if not mappings:
                 raise ValueError(
@@ -1116,12 +1116,12 @@ class check_output(BaseDataValidationDecorator):
         if len(validator) != 0:
             if importance is not None or len(default_validator_kwargs) > 0:
                 raise ValueError(
-                    f"Can provide *either* a list of custom validators or arguments for the default validator. "
-                    f"Instead received both."
+                    "Can provide *either* a list of custom validators or arguments for the default validator. "
+                    "Instead received both."
                 )
         else:
             if importance is None:
-                raise ValueError(f"Must supply an importance level if using the default validator.")
+                raise ValueError("Must supply an importance level if using the default validator.")
 
     def validate(self, fn: Callable):
         """Validates that the check_output node works on the function on which it was called


### PR DESCRIPTION
Contributes to #161.

## Changes

- removes uses of f-strings without any templating

## Testing

N/A

## Notes

Contributes to #161 because `flake8` detected these uses.

```text
./hamilton/function_modifiers.py:323:30: F541 f-string is missing placeholders
./hamilton/function_modifiers.py:1119:21: F541 f-string is missing placeholders
./hamilton/function_modifiers.py:1124:34: F541 f-string is missing placeholders
./hamilton/experimental/h_async.py:114:17: F541 f-string is missing placeholders
./hamilton/experimental/h_async.py:141:17: F541 f-string is missing placeholders
./hamilton/data_quality/default_validators.py:224:30: F541 f-string is missing placeholders
./hamilton/data_quality/default_validators.py:418:13: F541 f-string is missing placeholders
./hamilton/data_quality/pandera_validators.py:23:16: F541 f-string is missing placeholders
./hamilton/dev_utils/deprecation.py:125:27: F541 f-string is missing placeholders
./hamilton/dev_utils/deprecation.py:143:27: F541 f-string is missing placeholders
```

Fixing such issues and having `flake8` catch them is useful because using f-strings with string literals that don't have templating adds a small amount of unnecessary computation.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
