### PR TITLE
Add pandas index checks

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -71,6 +71,10 @@ class PandasDataFrameResult(ResultMixin):
                 if isinstance(output_value.index, index_type):
                     # it's a time index -- these will produce garbage if not aligned properly.
                     time_indexes[dict_key].append(output_name)
+            elif isinstance(output_value, pd.Index):
+                # there is no index on this - so it's just an integer one.
+                int_index = pd.Series([1, 2, 3], index=[0, 1, 2])
+                dict_key = f"{int_index.index.__class__.__name__}:::{int_index.dtype}"
             else:
                 dict_key = "no-index"
                 no_indexes[dict_key].append(output_name)

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -5,7 +5,7 @@ It cannot import hamilton.graph, or hamilton.driver.
 import abc
 import collections
 import inspect
-import typing
+from typing import Any, Dict, List, Tuple, Type
 
 import numpy as np
 import pandas as pd
@@ -23,7 +23,7 @@ class ResultMixin(object):
 
     @staticmethod
     @abc.abstractmethod
-    def build_result(**outputs: typing.Dict[str, typing.Any]) -> typing.Any:
+    def build_result(**outputs: Dict[str, Any]) -> Any:
         """This function builds the result given the computed values."""
         pass
 
@@ -32,7 +32,7 @@ class DictResult(ResultMixin):
     """Simple function that returns the dict of column -> value results."""
 
     @staticmethod
-    def build_result(**outputs: typing.Dict[str, typing.Any]) -> typing.Dict:
+    def build_result(**outputs: Dict[str, Any]) -> Dict:
         """This function builds a simple dict of output -> computed values."""
         return outputs
 
@@ -41,7 +41,7 @@ class PandasDataFrameResult(ResultMixin):
     """Mixin for building a pandas dataframe from the result"""
 
     @staticmethod
-    def build_result(**outputs: typing.Dict[str, typing.Any]) -> pd.DataFrame:
+    def build_result(**outputs: Dict[str, Any]) -> pd.DataFrame:
         # TODO check inputs are pd.Series, arrays, or scalars -- else error
         # TODO do a basic index check across pd.Series and flag where mismatches occur?
         if len(outputs) == 1:
@@ -61,7 +61,7 @@ class NumpyMatrixResult(ResultMixin):
     """
 
     @staticmethod
-    def build_result(**outputs: typing.Dict[str, typing.Any]) -> np.matrix:
+    def build_result(**outputs: Dict[str, Any]) -> np.matrix:
         """Builds a numpy matrix from the passed in, inputs.
 
         :param outputs: function_name -> np.array.
@@ -108,7 +108,7 @@ class HamiltonGraphAdapter(ResultMixin):
 
     @staticmethod
     @abc.abstractmethod
-    def check_input_type(node_type: typing.Type, input_value: typing.Any) -> bool:
+    def check_input_type(node_type: Type, input_value: Any) -> bool:
         """Used to check whether the user inputs match what the execution strategy & functions can handle.
 
         :param node_type: The type of the node.
@@ -119,7 +119,7 @@ class HamiltonGraphAdapter(ResultMixin):
 
     @staticmethod
     @abc.abstractmethod
-    def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:
+    def check_node_type_equivalence(node_type: Type, input_type: Type) -> bool:
         """Used to check whether two types are equivalent.
 
         This is used when the function graph is being created and we're statically type checking the annotations
@@ -132,7 +132,7 @@ class HamiltonGraphAdapter(ResultMixin):
         pass
 
     @abc.abstractmethod
-    def execute_node(self, node: node.Node, kwargs: typing.Dict[str, typing.Any]) -> typing.Any:
+    def execute_node(self, node: node.Node, kwargs: Dict[str, Any]) -> Any:
         """Given a node that represents a hamilton function, execute it.
         Note, in some adapters this might just return some type of "future".
 
@@ -147,8 +147,8 @@ class SimplePythonDataFrameGraphAdapter(HamiltonGraphAdapter, PandasDataFrameRes
     """This is the default (original Hamilton) graph adapter. It uses plain python and builds a dataframe result."""
 
     @staticmethod
-    def check_input_type(node_type: typing.Type, input_value: typing.Any) -> bool:
-        if node_type == typing.Any:
+    def check_input_type(node_type: Type, input_value: Any) -> bool:
+        if node_type == Any:
             return True
         elif inspect.isclass(node_type) and isinstance(input_value, node_type):
             return True
@@ -171,10 +171,10 @@ class SimplePythonDataFrameGraphAdapter(HamiltonGraphAdapter, PandasDataFrameRes
         return False
 
     @staticmethod
-    def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:
+    def check_node_type_equivalence(node_type: Type, input_type: Type) -> bool:
         return node_type == input_type
 
-    def execute_node(self, node: node.Node, kwargs: typing.Dict[str, typing.Any]) -> typing.Any:
+    def execute_node(self, node: node.Node, kwargs: Dict[str, Any]) -> Any:
         return node.callable(**kwargs)
 
 
@@ -186,6 +186,6 @@ class SimplePythonGraphAdapter(SimplePythonDataFrameGraphAdapter):
         if self.result_builder is None:
             raise ValueError("You must provide a ResultMixin object for `result_builder`.")
 
-    def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:
+    def build_result(self, **outputs: Dict[str, Any]) -> Any:
         """Delegates to the result builder function supplied."""
         return self.result_builder.build_result(**outputs)

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -64,7 +64,11 @@ class PandasDataFrameResult(ResultMixin):
         for output_name, output_value in outputs.items():
             if isinstance(output_value, (pd.DataFrame, pd.Series)):
                 dict_key = f"{output_value.index.__class__.__name__}:::{output_value.index.dtype}"
-                if isinstance(output_value.index, pd_extension.NDArrayBackedExtensionIndex):
+                try:
+                    index_type = getattr(pd_extension, "NDArrayBackedExtensionIndex")
+                except AttributeError:  # for python 3.6 & pandas 1.1.5
+                    index_type = getattr(pd_extension, "ExtensionIndex")
+                if isinstance(output_value.index, index_type):
                     # it's a time index -- these will produce garbage if not aligned properly.
                     time_indexes[dict_key].append(output_name)
             else:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -177,7 +177,199 @@ def test_PandasDataFrameResult_build_result(outputs, expected_result):
     ],
 )
 def test_PandasDataFrameResult_build_result_errors(outputs):
-    """Tests the happy case of PandasDataFrameResult.build_result()"""
+    """Tests the error case of PandasDataFrameResult.build_result()"""
     pdfr = base.PandasDataFrameResult()
     with pytest.raises(ValueError):
         pdfr.build_result(**outputs)
+
+
+@pytest.mark.parametrize(
+    "outputs,expected_result",
+    [
+        ({"a": pd.Series([1, 2, 3])}, ({"RangeIndex:::int64": ["a"]}, {}, {})),
+        (
+            {"a": pd.Series([1, 2, 3]), "b": pd.Series([3, 4, 5])},
+            ({"RangeIndex:::int64": ["a", "b"]}, {}, {}),
+        ),
+        (
+            {
+                "b": pd.Series(
+                    [3, 4, 5], index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS")
+                )
+            },
+            (
+                {"DatetimeIndex:::datetime64[ns]": ["b"]},
+                {"DatetimeIndex:::datetime64[ns]": ["b"]},
+                {},
+            ),
+        ),
+        ({"c": 1}, ({"no-index": ["c"]}, {}, {"no-index": ["c"]})),
+        (
+            {
+                "a": pd.Series([1, 2, 3]),
+                "b": 1,
+                "c": pd.Series(
+                    [3, 4, 5], index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS")
+                ),
+            },
+            (
+                {
+                    "DatetimeIndex:::datetime64[ns]": ["c"],
+                    "RangeIndex:::int64": ["a"],
+                    "no-index": ["b"],
+                },
+                {"DatetimeIndex:::datetime64[ns]": ["c"]},
+                {"no-index": ["b"]},
+            ),
+        ),
+        ({"a": pd.DataFrame({"a": [1, 2, 3]})}, ({"RangeIndex:::int64": ["a"]}, {}, {})),
+    ],
+    ids=[
+        "int-index",
+        "int-index-double",
+        "ts-index",
+        "no-index",
+        "multiple-different-indexes",
+        "df-index",
+    ],
+)
+def test_PandasDataFrameResult_pandas_index_types(outputs, expected_result):
+    """Tests exercising the function to return pandas index types from outputs"""
+    pdfr = base.PandasDataFrameResult()
+    actual = pdfr.pandas_index_types(outputs)
+    assert dict(actual[0]) == expected_result[0]
+    assert dict(actual[1]) == expected_result[1]
+    assert dict(actual[2]) == expected_result[2]
+
+
+@pytest.mark.parametrize(
+    "all_index_types,time_indexes,no_indexes,expected_result",
+    [
+        ({"foo": ["a", "b", "c"]}, {}, {}, True),
+        ({"int-index": ["a"], "no-index": ["b"]}, {}, {"no-index": ["b"]}, True),
+        ({"ts-1": ["a"], "ts-2": ["b"]}, {"ts-1": ["a"], "ts-2": ["b"]}, {}, False),
+        ({"float-index": ["a"], "int-index": ["b"]}, {}, {}, False),
+        ({"no-index": ["a", "b"]}, {}, {"no-index": ["a", "b"]}, False),
+    ],
+    ids=[
+        "all-the-same",  # True
+        "single-index-with-no-index",  # True
+        "multiple-ts",  # False
+        "multiple-indexes-not-ts",  # False
+        "no-indexes-at-all",  # False4
+    ],
+)
+def test_PandasDataFrameResult_check_pandas_index_types_match(
+    all_index_types, time_indexes, no_indexes, expected_result
+):
+    """Tests exercising the function to determine whether pandas index types match"""
+    # setup to test conditional if statement on logger level
+    import logging
+
+    logger = logging.getLogger("hamilton.base")  # get logger of base module.
+    logger.setLevel(logging.DEBUG)
+    pdfr = base.PandasDataFrameResult()
+    actual = pdfr.check_pandas_index_types_match(all_index_types, time_indexes, no_indexes)
+    assert actual == expected_result
+
+
+@pytest.mark.parametrize(
+    "outputs,expected_result",
+    [
+        ({"a": pd.Series([1, 2, 3])}, pd.DataFrame({"a": pd.Series([1, 2, 3])})),
+        (
+            {
+                "a": pd.Series(
+                    [1, 2, 3], index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS")
+                ),
+                "b": pd.Series(
+                    [3, 4, 5], index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS")
+                ),
+            },
+            pd.DataFrame(
+                {
+                    "a": pd.Series(
+                        [1, 2, 3],
+                        index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS"),
+                    ),
+                    "b": pd.Series(
+                        [3, 4, 5],
+                        index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS"),
+                    ),
+                }
+            ),
+        ),
+        (
+            {
+                "a": pd.Series(
+                    [1, 2, 3], index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS")
+                ),
+                "b": 4,
+            },
+            pd.DataFrame(
+                {
+                    "a": pd.Series(
+                        [1, 2, 3],
+                        index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS"),
+                    ),
+                    "b": 4,
+                }
+            ),
+        ),
+    ],
+    ids=[
+        "test-same-index-simple",
+        "test-same-index-ts",
+        "test-index-with-scalar",
+    ],
+)
+def test_StrictIndexTypePandasDataFrameResult_build_result(outputs, expected_result):
+    """Tests the happy case of StrictIndexTypePandasDataFrameResult.build_result()"""
+    sitpdfr = base.StrictIndexTypePandasDataFrameResult()
+    actual = sitpdfr.build_result(**outputs)
+    pd.testing.assert_frame_equal(actual, expected_result)
+
+
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        (
+            {
+                "a": pd.Series([1, 2, 3], index=[0, 1, 2]),
+                "b": pd.Series([1, 2, 3], index=[0.0, 1.0, 2.0]),
+            }
+        ),
+        (
+            {
+                "series1": pd.Series(
+                    [1, 2, 3], index=pd.DatetimeIndex(["2022-01", "2022-02", "2022-03"], freq="MS")
+                ),
+                "series2": pd.Series(
+                    [4, 5, 6],
+                    index=pd.PeriodIndex(year=[2022, 2022, 2022], month=[1, 2, 3], freq="M"),
+                ),
+                "series3": pd.Series(
+                    [4, 5, 6],
+                    index=pd.PeriodIndex(
+                        year=[2022, 2022, 2022], month=[1, 1, 1], day=[3, 4, 5], freq="B"
+                    ),
+                ),
+                "series4": pd.Series(
+                    [4, 5, 6],
+                    index=pd.PeriodIndex(
+                        year=[2022, 2022, 2022], month=[1, 1, 1], day=[4, 11, 18], freq="W"
+                    ),
+                ),
+            }
+        ),
+    ],
+    ids=[
+        "test-int-float",
+        "test-different-ts-indexes",
+    ],
+)
+def test_StrictIndexTypePandasDataFrameResult_build_result_errors(outputs):
+    """Tests the error case of StrictIndexTypePandasDataFrameResult.build_result()"""
+    sitpdfr = base.StrictIndexTypePandasDataFrameResult()
+    with pytest.raises(ValueError):
+        sitpdfr.build_result(**outputs)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -137,12 +137,23 @@ def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, 
                 {"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13]), "c": pd.Series([1, 1, 1])}
             ),
         ),
+        (
+            {
+                "a": pd.Series([1, 2, 3]),
+                "b": pd.Series([11, 12, 13]),
+                "c": pd.Series([11, 12, 13]).index,
+            },
+            pd.DataFrame(
+                {"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13]), "c": pd.Series([0, 1, 2])}
+            ),
+        ),
     ],
     ids=[
         "test-single-series",
         "test-single-dataframe",
         "test-multiple-series",
         "test-multiple-series-with-scalar",
+        "test-multiple-series-with-index",
     ],
 )
 def test_PandasDataFrameResult_build_result(outputs, expected_result):
@@ -223,6 +234,7 @@ def test_PandasDataFrameResult_build_result_errors(outputs):
             ),
         ),
         ({"a": pd.DataFrame({"a": [1, 2, 3]})}, ({"RangeIndex:::int64": ["a"]}, {}, {})),
+        ({"a": pd.Series([1, 2, 3]).index}, ({"Int64Index:::int64": ["a"]}, {}, {})),
     ],
     ids=[
         "int-index",
@@ -231,6 +243,7 @@ def test_PandasDataFrameResult_build_result_errors(outputs):
         "no-index",
         "multiple-different-indexes",
         "df-index",
+        "index-object",
     ],
 )
 def test_PandasDataFrameResult_pandas_index_types(outputs, expected_result):


### PR DESCRIPTION
Adds some basic index type checking to df creation
    
Related to issue #191, this commit is to help surface index type issues.
    
Specifically:
    
1. Warn if there are index type mismatches.
2. Require you to set your logger to debug if you want to see more details.
3. Provide a "ResultBuilder" class that uses strict index type matching so if you
want to error on index type mismatches, this is the results builder to use.
    
I don't think we should build anything more custom unless there's a clear
common use case - user contributed result builders sound like an interesting idea here though.

To use the new result builder the code should be the following:

```python
from hamilton import base, driver
strict_builder = base.StrictIndexTypePandasDataFrameResult()
adapter = base.SimplePythonGraphAdapter(strict_builder)
...
dr =  driver.Driver(config, *modules, adapter=adapter)
df = dr.execute(...)  # this will now error if index types mismatch.
```

## Changes

- one clean up commit around imports
- one commit with the index type changes
- one commit to handle python 3.6 support and pandas index classes changing

## Testing

1. Unit tests.
2. Checked things in the REPL locally against the examples in #191.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
- [ ] python 3.8
- [x] python 3.9
