### PR TITLE
Adding container image for running examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ To use it hit `option + mouse click` to create multiple cursors. `Esc` to revert
 - Vincent Chu (@vslchusf)
 - Christopher Prohm (@chmp)
 - James Lamb (@jameslamb)
+- Avnish Pal (@bovem)
 
 ## Bug Hunters/Special Mentions
 - Nils Olsson (@nilsso)

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9
+
+RUN apt update -y &&\
+    apt install git openjdk-11-jdk -y &&\
+    git clone https://github.com/bovem/hamilton.git --branch=examples-dockerfile &&\
+    cd hamilton/examples &&\
+    bash make_python_virtualenv.sh
+
+ENTRYPOINT ["/bin/bash"]

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.9
+FROM python:3.9.14-slim-buster
 
 RUN apt update -y &&\
     apt install git openjdk-11-jdk -y &&\
-    git clone https://github.com/bovem/hamilton.git --branch=examples-dockerfile &&\
+    git clone https://github.com/stitchfix/hamilton.git --branch=main &&\
     cd hamilton/examples &&\
     bash make_python_virtualenv.sh
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,3 +21,34 @@ folders.
 Under `model_examples` you'll find a how you could apply Hamilton to model your ML workflow.
 Check it out to get a sense for how Hamilton could make your ML pipelines reusable/general
 components...
+
+## Running examples through docker image
+Examples could also be executed through the provided docker image.
+Each example directory inside docker image contains a `hamilton-env` Python virtual environment.
+`hamilton-env` environment contains all the dependencies required to run the example.
+
+NOTE: If you already have the container image you can skip to container creation (step 3)
+
+1. Change directory to `examples`
+```bash
+cd hamilton/examples
+```
+
+2. Build the container image.
+```bash
+docker build --tag hamilton-example .
+```
+Docker build takes around `6m16.298s` depending on the system configuration and network.
+Alternatively, you can pull the container image from here: ...
+
+3. Creating a container
+```bash
+docker run -it --rm --name hamilton-example hamilton-example
+```
+
+4. Running the `hello_world` example inside the container
+```bash
+cd hamilton/examples/hello_world
+source hamilton-env/bin/activate
+python my_script.py
+```

--- a/examples/async/requirements.txt
+++ b/examples/async/requirements.txt
@@ -1,3 +1,5 @@
 aiohttp
+async
 fastapi
+sf-hamilton
 uvicorn

--- a/examples/hello_world/requirements.txt
+++ b/examples/hello_world/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+sf-hamilton

--- a/examples/make_python_virtualenv.sh
+++ b/examples/make_python_virtualenv.sh
@@ -1,0 +1,33 @@
+# This script is used to create separate python virtual environments for individual examples
+# A python virtual environment named "hamilton-env" is created in every directory containing requirements.txt file
+
+# USAGE (inside hamilton/examples directory): bash make_python_virtualenv.sh
+
+# Get a list of all the folders containing "requirements.txt" file
+export folders=$(find . -name 'requirements.txt' -printf '%h\n');
+
+echo "List of all folders containing requirements.txt";
+echo $folders;
+
+for folder in $folders; do
+    # Change directory
+    pushd $folder;
+
+    # Remove previous hamilton python virtual environment
+    rm -rf ./hamilton-env;
+
+    # Create a new python virtual environment named "hamilton"
+    python3 -m venv hamilton-env;
+
+    # Change to that virtual environment
+    source ./hamilton-env/bin/activate;
+
+    # Install the requirements listed in hamilton virtual environment
+    pip install -r requirements.txt;
+
+    # Deactivate the virtual environment
+    deactivate;
+
+    # Return to the examples folder
+    popd;
+done


### PR DESCRIPTION
Added dockerfile for testing examples in a container environment.

## Changes

- Added a dockerfile for the image that could be used for running examples.
- Each example folder has a python virtual environment named `hamilton` that should be activated first before running the example.

## Testing

- Build the container image
```bash
docker build --tag hamilton-example .
```

- Creating a container
```bash
docker run -it --rm --name hamilton-example hamilton-example
```

- Running the `hello_world` example inside the container
```bash
cd hamilton/example/hello_world
source hamilton-env/bin/activate
python my_script.py
```

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
- [x] python 3.9 (Docker Environment)