### PR TITLE
Makes the fastapi async example more robust

### DIFF
--- a/examples/async/async_module.py
+++ b/examples/async/async_module.py
@@ -1,11 +1,19 @@
 import asyncio
+import json
+import logging
 
 import aiohttp
 import fastapi
 
+logger = logging.getLogger(__name__)
+
 
 async def request_raw(request: fastapi.Request) -> dict:
-    return await request.json()
+    try:
+        return await request.json()
+    except json.JSONDecodeError as e:
+        logger.warning(f"Unable to get JSON from request. Error is:\n{e}")
+        return {}
 
 
 def foo(request_raw: dict) -> str:

--- a/examples/async/fastapi_example.py
+++ b/examples/async/fastapi_example.py
@@ -12,3 +12,10 @@ async def call(request: fastapi.Request) -> dict:
     dr = h_async.AsyncDriver({}, async_module)
     input_data = {"request": request}
     return await dr.raw_execute(["pipeline"], inputs=input_data)
+
+
+if __name__ == "__main__":
+    # If you run this as a script, then the app will be started on localhost:8000
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
When you use `/docs` to create the request, it does not pass in an empty dict, so making sure the path does not break.

## Changes

- adds try/except to async example
- adds way to run fastapi by just running `fastapi_example.py`

## Testing

1. Works locally

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [x] python 3.9
