### PR TITLE
Tweaks warning message from pandas index check

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -143,7 +143,8 @@ class PandasDataFrameResult(ResultMixin):
             logger.warning(
                 "It appears no Pandas index type was detected. This will likely break when trying to "
                 "create a DataFrame. E.g. are you requesting all scalar values? Use a different result "
-                "builder or return at least one Pandas object with an index."
+                "builder or return at least one Pandas object with an index. "
+                "Ignore this warning if you're using DASK for now."
             )
             types_match = False
         if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
If using a dask dataframe or series the index type checker will not capture it because it only checks for pandas types. So adding note to ignore if using DASK.

We will have to figure out how to support this -- likely with a specific result builder for Dask that takes this into account, or something like that.


## Changes

- adds to warning message

## Testing

1. Works locally.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
