### PR TITLE
Example showing what we would need to modify to enable user question

### DIFF
--- a/examples/user_help/module_import_question/README.md
+++ b/examples/user_help/module_import_question/README.md
@@ -1,0 +1,3 @@
+Context:
+ - hamilton is required as a dependency in the python module if you use any decorators
+ - how can we reuse the functions without having to have hamilton?

--- a/examples/user_help/module_import_question/hamilton_plain_functions.py
+++ b/examples/user_help/module_import_question/hamilton_plain_functions.py
@@ -1,0 +1,15 @@
+"""Module that brings in Hamilton as a dependency"""
+
+import plain_functions
+
+from hamilton import function_modifiers
+
+moving_average__v1 = function_modifiers.config.when(ma_type="v1")(
+    plain_functions.moving_average__v1
+)
+
+moving_average__v2 = function_modifiers.config.when(ma_type="v2")(
+    plain_functions.moving_average__v2
+)
+
+some_other_function = plain_functions.some_other_function

--- a/examples/user_help/module_import_question/plain_functions.py
+++ b/examples/user_help/module_import_question/plain_functions.py
@@ -1,0 +1,16 @@
+"""Module that defines functions without importing Hamilton"""
+
+
+def moving_average__v1(input: dict) -> float:
+    # some logic
+    return 2.0
+
+
+def moving_average__v2(input: dict, other_input: float) -> float:
+    # some logic
+    return 2.0 * other_input
+
+
+def some_other_function(moving_average: float) -> float:
+    # some logic
+    return moving_average

--- a/examples/user_help/module_import_question/run.py
+++ b/examples/user_help/module_import_question/run.py
@@ -1,0 +1,11 @@
+import hamilton_plain_functions
+
+from hamilton import base, driver
+
+config = {"ma_type": "v1"}
+adapter = base.SimplePythonGraphAdapter(base.DictResult())
+dr = driver.Driver(config, hamilton_plain_functions, adapter=adapter)
+result = dr.execute(
+    ["moving_average", "some_other_function"], inputs={"input": {}, "other_input": 2.0}
+)
+print(result)

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -21,6 +21,15 @@ def is_submodule(child: ModuleType, parent: ModuleType):
     return parent.__name__ in child.__name__
 
 
+def special_case(current_module: ModuleType, function_module: ModuleType):
+    """Function that allows us to use functions from another module only if
+    the current module has `hamilton_` prepended to it, to indicate that it
+    maps 1-1 with the function module and we want to therefore include these
+    functions for DAG construction.
+    """
+    return "hamilton_" + current_module.__name__ == function_module.__name__
+
+
 def find_functions(function_module: ModuleType) -> List[Tuple[str, Callable]]:
     """Function to determine the set of functions we want to build a graph from.
 
@@ -32,7 +41,10 @@ def find_functions(function_module: ModuleType) -> List[Tuple[str, Callable]]:
         return (
             inspect.isfunction(fn)
             and not fn.__name__.startswith("_")
-            and is_submodule(inspect.getmodule(fn), function_module)
+            and (
+                is_submodule(inspect.getmodule(fn), function_module)
+                or special_case(inspect.getmodule(fn), function_module)
+            )
         )
 
     return [f for f in inspect.getmembers(function_module, predicate=valid_fn)]


### PR DESCRIPTION
If the user wants to reuse hamilton functions without hamilton, this commit shows one way to do it -- and what would be required on Hamilton's side to support it.

Basically we'd need a convention. Not sure it's a good idea. Probably easier to instead have boilerplate code people use to try/except the import if hamilton does not exist and have the decorators be identity functions...
