### PR TITLE
simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,30 +2,16 @@
 
 ## Changes
 
--
-
-## Testing
-
-1.
-
 ## Notes
 
 ## Checklist
 
 - [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
 - [ ] Changes are limited to a single goal (no scope creep)
-- [ ] Code can be automatically merged (no conflicts)
 - [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
-- [ ] Passes all existing automated tests
 - [ ] Any _change_ in functionality is tested
 - [ ] New functions are documented (with a description, list of inputs, and expected output)
 - [ ] Placeholder code is flagged / future TODOs are captured in comments
 - [ ] Project documentation has been updated if adding/changing functionality.
-- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
 
-## Testing checklist
-
-### Python - local testing
-
-- [ ] python 3.6
-- [ ] python 3.7
+## How I tested this

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+## How I tested this
+
 ## Notes
 
 ## Checklist
@@ -13,5 +15,3 @@
 - [ ] New functions are documented (with a description, list of inputs, and expected output)
 - [ ] Placeholder code is flagged / future TODOs are captured in comments
 - [ ] Project documentation has been updated if adding/changing functionality.
-
-## How I tested this


### PR DESCRIPTION
This PR proposes some simplifications to the pull request template.

I believe it'll make contributing a bit less intimidating for beginners, and reduce the amount of boilerplate text that has to be read by maintainers reviewing PRs.

## Changes

I'll leave inline comments explaining each proposed change.

## Testing

N/A

## Notes

N/A

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
