### PR TITLE
fix a few flake8 warnings

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -118,17 +118,17 @@ class PandasDataFrameResult(ResultMixin):
         # if there is more than one time index
         if time_indexes_length > 1:
             logger.warning(
-                f"WARNING: Time/Categorical index type mismatches detected - check output to ensure Pandas "
-                f"is doing what you intend to do. Else change the index types to match. Set logger to debug "
-                f"to see index types."
+                "WARNING: Time/Categorical index type mismatches detected - check output to ensure Pandas "
+                "is doing what you intend to do. Else change the index types to match. Set logger to debug "
+                "to see index types."
             )
             types_match = False
         # if there is more than one index type and it's not explained by the time indexes then
         if number_with_indexes > 1 and all_indexes_length > time_indexes_length:
             logger.warning(
-                f"WARNING: Multiple index types detected - check output to ensure Pandas is "
-                f"doing what you intend to do. Else change the index types to match. Set logger to debug to "
-                f"see index types."
+                "WARNING: Multiple index types detected - check output to ensure Pandas is "
+                "doing what you intend to do. Else change the index types to match. Set logger to debug to "
+                "see index types."
             )
             types_match = False
         elif number_with_indexes == 1 and no_index_length > 0:

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -423,7 +423,7 @@ class FunctionGraph(object):
                         kwargs[dependency.name] = computed[dependency.name]
                 try:
                     value = adapter.execute_node(node_, kwargs)
-                except Exception as e:
+                except Exception:
                     logger.exception(f"Node {node_.name} encountered an error")
                     raise
             computed[node_.name] = value

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -309,7 +309,7 @@ def test_no_code_validator():
         ensure_function_empty(yes_code)
 
 
-## Functions for  @does -- these are the functions we're "replacing"
+# Functions for  @does -- these are the functions we're "replacing"
 def _no_params() -> int:
     pass
 
@@ -330,7 +330,7 @@ def _three_params_with_defaults(a: int, b: int = 1, c: int = 2) -> int:
     pass
 
 
-## functions we can/can't replace them with
+# functions we can/can't replace them with
 def _empty() -> int:
     return 1
 


### PR DESCRIPTION
Contributes to #161.

## Changes

Fixes the following minor `flake8` warnings.

```text
./hamilton/graph.py:426:17: F841 local variable 'e' is assigned to but never used
./hamilton/base.py:121:17: F541 f-string is missing placeholders
./hamilton/base.py:129:17: F541 f-string is missing placeholders
./tests/test_function_modifiers.py:312:1: E266 too many leading '#' for block comment
./tests/test_function_modifiers.py:333:1: E266 too many leading '#' for block comment
```

## Testing

```shell
pre-commit run --all-files
```

## Notes

Thanks for your time and consideration.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
