### PR TITLE
remove unnecessary code in tests

### DIFF
--- a/graph_adapter_tests/h_dask/test_h_dask.py
+++ b/graph_adapter_tests/h_dask/test_h_dask.py
@@ -46,7 +46,6 @@ def test_dask_graph_adapter_simple(client):
 
 def test_smoke_screen_module(client):
     config = {"region": "US"}
-    index = pd.Series(pd.DatetimeIndex(pd.date_range(start="20200101", end="20220801", freq="7d")))
     dr = driver.Driver(config, smoke_screen_module, adapter=h_dask.DaskGraphAdapter(client))
     output_columns = [
         "raw_acquisition_cost",

--- a/tests/test_function_modifiers.py
+++ b/tests/test_function_modifiers.py
@@ -740,11 +740,6 @@ def test_tags_invalid_value(value):
     assert not function_modifiers.tag._value_allowed(value)
 
 
-@pytest.mark.parametrize("value", [None, False, [], ["foo", "bar"]])
-def test_tags_invalid_value(value):
-    assert not function_modifiers.tag._value_allowed(value)
-
-
 def test_check_output_node_transform():
     decorator = check_output(
         importance="warn",


### PR DESCRIPTION
Contributes to #161.

## Changes

- removes one instance of duplicated test `test_tags_invalid_value` ([code link](https://github.com/stitchfix/hamilton/blob/e3501ef375376d15692486d779998a22806ef58c/tests/test_function_modifiers.py#L738-LL745))
- removes unused variable in one Dask test

These were detected by `flake8`.

```text
./tests/test_function_modifiers.py:744:1: F811 redefinition of unused 'test_tags_invalid_value' from line 739
./graph_adapter_tests/h_dask/test_h_dask.py:49:5: F841 local variable 'index' is assigned to but never used
```

## Testing

```shell
pre-commit run --all-files
```

## Notes

Thanks for your time and consideration.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
