### PR TITLE
[docs] restructure 'how to contribute' in developer guide

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -32,6 +32,12 @@ pip install \
     -r ./requirements-test.txt
 ```
 
+Set up `pre-commit`, which will run some lightweight formatting and linting tasks on every commit.
+
+```shell
+pre-commit install
+```
+
 ### Create a pull request
 
 Make sure your local copy of the `main` branch is up to date with the official `hamilton` repo.
@@ -47,7 +53,7 @@ git push origin main
 Create a new branch.
 
 ```shell
-git checkout -b feat/somme-feature
+git checkout -b feat/some-feature
 ```
 
 Make changes, commit them, and push them to your fork.
@@ -56,7 +62,13 @@ Make changes, commit them, and push them to your fork.
 git push origin HEAD
 ```
 
-Test your changes locally by following the steps in ["How to run unit tests"](#how-to-run-unit-tests).
+Test your changes locally with `pre-commit`...
+
+```shell
+pre-commit run --all-files
+```
+
+...and by following the steps in ["How to run unit tests"](#how-to-run-unit-tests).
 
 Navigate to https://github.com/stitchfix/hamilton/pulls and open a pull request.
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -9,17 +9,56 @@ This repository is organized as follows:
 
 ## How to contribute
 
-1. Checkout the repo. If external to Stitch Fix, fork the repo.
-2. Create a virtual environment for it. See python algo curriculum slides for details.
-3. Activate the virtual environment and install all dependencies. One for the package, one for making comparisons, one for running unit tests. I.e. `pip install -r requirements*.txt` should install all three for you.
-3. Make pycharm depend on that virtual environment & install required dependencies (it should prompt you because it'll read the requirements.txt file).
-4. `brew install pre-commit` if you haven't.
-5. Run `pre-commit install` from the root of the repository.
-6. Create a branch off of the latest master branch. `git checkout -b my_branch`.
-7. Do you work & commit it.
-8. Push to github and create a PR.
-9. When you push to github circle ci will kick off unit tests and migration tests (for Stitch Fix users only).
+### Set up your local dev environment
 
+Fork this repo and clone your fork. ([GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks))
+
+```shell
+GITHUB_USERNAME="YOUR-GITHUB-USERNAME" \
+git clone https://github.com/${GITHUB_USERNAME}/hamilton.git
+cd ./hamilton
+git remote add upstream https://github.com/stitchfix/hamilton.git
+```
+
+Create a virtual environment and install the project's dependencies into it.
+
+```shell
+python -m venv ./venv
+. ./venv/bin/activate
+
+pip install \
+    -r ./requirements.txt \
+    -r ./requirements-dev.txt \
+    -r ./requirements-test.txt
+```
+
+### Create a pull request
+
+Make sure your local copy of the `main` branch is up to date with the official `hamilton` repo.
+
+```shell
+git checkout main
+git pull upstream main
+
+# and might as well update your fork too!
+git push origin main
+```
+
+Create a new branch.
+
+```shell
+git checkout -b feat/somme-feature
+```
+
+Make changes, commit them, and push them to your fork.
+
+```shell
+git push origin HEAD
+```
+
+Test your changes locally by following the steps in ["How to run unit tests"](#how-to-run-unit-tests).
+
+Navigate to https://github.com/stitchfix/hamilton/pulls and open a pull request.
 
 ## How to run unit tests
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -20,7 +20,7 @@ cd ./hamilton
 git remote add upstream https://github.com/stitchfix/hamilton.git
 ```
 
-Create a virtual environment and install the project's dependencies into it.
+Install the project's dependencies in your preferred method for managing python dependencies. For example, run the following to use `venv`.
 
 ```shell
 python -m venv ./venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-exclude = build/,.git/
+exclude = build/,.git/,venv/
 ignore =
     E203, # whitespace before ':' \
     E402, # module level import not at top of file \


### PR DESCRIPTION
Contributes to #51.

## Changes

This PR proposes restructuring the `"How to contribute"` section in the developer guide, to hopefully make contributing easier for a wider range of possible contributors.

- removes assumption that contributors are using PyCharm
- removes assumption that contributors are on Macs (i.e. no `brew install`)
- adds code blocks to make instructions copy-pasteable
- replaces reference to "master" branch with `"main"`
- removes incorrect statement that the CI tests will only run on push if you are in the `stitchfix` organization

## Testing

```shell
pre-commit run --all-files
```

## Notes

I've never used `virtualenv` prior to contributing on this project (I typically use `conda`/`mamba` or just Docker instead), so please correct me if I've said anything incorrect about `virtualenv`  or if the pattern I've documented here is different from what you'd like contributors to follow.

Thanks for your time and consideration.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Python - local testing

- [ ] python 3.6
- [ ] python 3.7
