### PR TITLE
[ci] move CI logic into shell scripts (fixes #114)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+OPERATING_SYSTEM=$(uname -s)
+
+if [[ ${OPERATING_SYSTEM} == "Linux" ]]; then
+    sudo apt-get update -y
+    sudo apt-get install \
+        --no-install-recommends \
+        --yes \
+            graphviz
+fi
+
+# setting up a virtualenv isn't necessary for the "pre-commit" task
+if [[ ${TASK} != "pre-commit" ]]; then
+    mkdir -p "${HOME}/venvs/hamilton-venv"
+    python -m venv "${HOME}/venvs/hamilton-venv"
+    source "${HOME}/venvs/hamilton-venv/bin/activate"
+    pip install \
+        -r requirements-test.txt
+fi
+
+if [[ ${TASK} == "async" ]]; then
+    pip install \
+        -r graph_adapter_tests/h_async/requirements-test.txt
+fi
+
+if [[ ${TASK} == "pyspark" ]]; then
+    if [[ ${OPERATING_SYSTEM} == "Linux" ]]; then
+        sudo apt-get install \
+            --no-install-recommends \
+            --yes \
+                default-jre
+    fi
+fi
+
+echo "----- python version -----"
+python --version
+
+echo "----- pip version -----"
+pip --version
+echo "-----------------------"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+echo "running CI task '${TASK}'"
+
+if [[ ${TASK} == "pre-commit" ]]; then
+    pip install pre-commit
+    pre-commit run --all-files
+    exit 0
+fi
+
+echo "using venv at '${HOME}/venvs/hamilton-venv/bin/activate'"
+source "${HOME}/venvs/hamilton-venv/bin/activate"
+
+if [[ ${TASK} == "async" ]]; then
+    pip install .
+    pytest graph_adapter_tests/h_async
+    exit 0
+fi
+
+if [[ ${TASK} == "dask" ]]; then
+    pip install -e '.[dask]'
+    pytest graph_adapter_tests/h_dask
+    exit 0
+fi
+
+if [[ ${TASK} == "integrations" ]]; then
+    pip install -e '.[pandera]'
+    pytest tests/integrations
+    exit 0
+fi
+
+if [[ ${TASK} == "ray" ]]; then
+    pip install -e '.[ray]'
+    pytest graph_adapter_tests/h_ray
+    exit 0
+fi
+
+if [[ ${TASK} == "pyspark" ]]; then
+    pip install -e '.[pyspark]'
+    pytest graph_adapter_tests/h_spark
+    exit 0
+fi
+
+if [[ ${TASK} == "tests" ]]; then
+    pip install -e '.[ray]'
+    pytest graph_adapter_tests/h_ray
+    exit 0
+fi
+
+pip install .
+
+pytest \
+    --cov=hamilton \
+    --ignore tests/integrations \
+    tests/ \
+|| exit 1
+
+echo "Done running tests"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -44,17 +44,13 @@ if [[ ${TASK} == "pyspark" ]]; then
 fi
 
 if [[ ${TASK} == "tests" ]]; then
-    pip install -e '.[ray]'
-    pytest graph_adapter_tests/h_ray
+    pip install .
+    pytest \
+        --cov=hamilton \
+        --ignore tests/integrations \
+        tests/
     exit 0
 fi
 
-pip install .
-
-pytest \
-    --cov=hamilton \
-    --ignore tests/integrations \
-    tests/ \
-|| exit 1
-
-echo "Done running tests"
+echo "ERROR: did not recognize TASK '${TASK}'"
+exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,231 +1,77 @@
-## Python CircleCI 2.0 configuration file
-##
-## Check https://circleci.com/docs/2.0/language-python/ for more details
-##
-
-version: 2
+version: 2.1
 jobs:
-  build-py36:
+  test:
+    parameters:
+      python-version:
+        type: string
+      task:
+        type: string
     docker:
-      - image: circleci/python:3.6
-    environment:
-      TASK: tests
+      - image: circleci/python:<< parameters.python-version>>
     steps:
       - checkout
       - run:
-          name: install hamilton dependencies
-          command: |
-            .ci/setup.sh
+          name: install dependencies
+          command: .ci/setup.sh
       - run:
           name: run tests
-          command: |
-            .ci/test.sh
-  build-py37:
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      TASK: tests
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies
-          command: |
-           .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  build-py38:
-    docker:
-      - image: circleci/python:3.8
-    environment:
-      TASK: tests
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  build-py39:
-    docker:
-      - image: circleci/python:3.9
-    environment:
-      TASK: tests
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-
-  pre-commit:
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - checkout
-      - run:
-          name: run pre-commit hooks
-          command: |
-            pip install pre-commit
-            pre-commit run --all-files
-  dask-py36:
-    docker:
-      - image: circleci/python:3.6
-    environment:
-      TASK: dask
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies + dask
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  dask-py37:
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      TASK: dask
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies + dask
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  ray-py37:
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      TASK: ray
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies + ray
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  spark-py38:
-    docker:
-      - image: circleci/python:3.8
-    environment:
-      TASK: pyspark
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies + spark
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  integrations-py36:
-    docker:
-      - image: circleci/python:3.6
-    environment:
-      TASK: integrations
-    steps:
-      - checkout
-      - run:
-          name: install all python dependencies for integrations
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  integrations-py37:
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      TASK: integrations
-    steps:
-      - checkout
-      - run:
-          name: install all python dependencies for integrations
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  integrations-py38:
-    docker:
-      - image: circleci/python:3.8
-    environment:
-      TASK: integrations
-    steps:
-      - checkout
-      - run:
-          name: install all python dependencies for integrations
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  integrations-py39:
-    docker:
-      - image: circleci/python:3.9
-    environment:
-      TASK: integrations
-    steps:
-      - checkout
-      - run:
-          name: install all python dependencies for integrations
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
-  asyncio-py39:
-    docker:
-      - image: circleci/python:3.9
-    environment:
-      TASK: async
-    steps:
-      - checkout
-      - run:
-          name: install hamilton dependencies + testing dependencies
-          command: |
-            .ci/setup.sh
-      - run:
-          name: run tests
-          command: |
-            .ci/test.sh
+          command: .ci/test.sh
 workflows:
-  version: 2
   unit-test-workflow:
     jobs:
-      - build-py36
-      - build-py37
-      - build-py38
-      - build-py39
-      - pre-commit
-      - dask-py36
-      - dask-py37
-      - ray-py37
-      - spark-py38
-      - integrations-py36
-      - integrations-py37
-      - integrations-py38
-      - integrations-py39
-      - asyncio-py39
+      - test:
+          name: build-py36
+          python-version: '3.6'
+          task: tests
+      - test:
+          name: build-py37
+          python-version: '3.7'
+          task: tests
+      - test:
+          name: build-py38
+          python-version: '3.8'
+          task: tests
+      - test:
+          name: build-py39
+          python-version: '3.9'
+          task: tests
+      - test:
+          name: pre-commit
+          python-version: '3.9'
+          task: pre-commit
+      - test:
+          name: dask-py36
+          python-version: '3.6'
+          task: dask
+      - test:
+          name: dask-py37
+          python-version: '3.7'
+          task: dask
+      - test:
+          name: ray-py37
+          python-version: '3.7'
+          task: ray
+      - test:
+          name: spark-py38
+          python-version: '3.8'
+          task: pyspark
+      - test:
+          name: integrations-py36
+          python-version: '3.6'
+          task: integrations
+      - test:
+          name: integrations-py37
+          python-version: '3.7'
+          task: integrations
+      - test:
+          name: integrations-py38
+          python-version: '3.8'
+          task: integrations
+      - test:
+          name: integrations-py39
+          python-version: '3.9'
+          task: integrations
+      - test:
+          name: asyncio-py39
+          python-version: '3.9'
+          task: asyncio

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
           name: run tests
           command: |
             .ci/test.sh
-
   build-py37:
     docker:
       - image: circleci/python:3.7
@@ -36,7 +35,6 @@ jobs:
           name: run tests
           command: |
             .ci/test.sh
-
   build-py38:
     docker:
       - image: circleci/python:3.8
@@ -52,7 +50,6 @@ jobs:
           name: run tests
           command: |
             .ci/test.sh
-
   build-py39:
     docker:
       - image: circleci/python:3.9
@@ -126,30 +123,19 @@ jobs:
             .ci/test.sh
   spark-py38:
     docker:
-      - image: cimg/openjdk:14.0   # need java on it
-
+      - image: circleci/python:3.8
+    environment:
+      TASK: pyspark
     steps:
       - checkout
       - run:
           name: install hamilton dependencies + spark
           command: |
-            # venv & pip weren't installed -- so have to do this hacky stuff
-            sudo apt-get update
-            sudo apt-get install aptitude
-            sudo aptitude install python3.8-venv -y
-            python3.8 -m venv venv
-            . venv/bin/activate
-            python3.8 --version
-            pip3.8 --version
-            pip3.8 install -r requirements-test.txt
-            pip3.8 install -e ".[pyspark]" # note bdist will error, but things install fine enough to run!
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest graph_adapter_tests/h_spark
+            .ci/test.sh
   integrations-py36:
     docker:
       - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,4 +76,4 @@ workflows:
       - test:
           name: asyncio-py39
           python-version: '3.9'
-          task: asyncio
+          task: async

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,97 +8,66 @@ jobs:
   build-py36:
     docker:
       - image: circleci/python:3.6
-
+    environment:
+      TASK: tests
     steps:
       - checkout
       - run:
           name: install hamilton dependencies
           command: |
-            sudo apt install graphviz
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -r requirements.txt
-        # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest --cov=hamilton tests/ --ignore tests/integrations
+            .ci/test.sh
 
   build-py37:
     docker:
       - image: circleci/python:3.7
-
+    environment:
+      TASK: tests
     steps:
       - checkout
       - run:
           name: install hamilton dependencies
           command: |
-            sudo apt install graphviz
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -r requirements.txt
-
-      # run tests!
+           .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest --cov=hamilton tests/ --ignore tests/integrations
+            .ci/test.sh
 
   build-py38:
     docker:
       - image: circleci/python:3.8
-
+    environment:
+      TASK: tests
     steps:
       - checkout
       - run:
           name: install hamilton dependencies
           command: |
-            sudo apt install graphviz
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -r requirements.txt
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest --cov=hamilton tests/ --ignore tests/integrations
+            .ci/test.sh
 
   build-py39:
     docker:
       - image: circleci/python:3.9
-
+    environment:
+      TASK: tests
     steps:
       - checkout
       - run:
           name: install hamilton dependencies
           command: |
-            sudo apt install graphviz
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -r requirements.txt
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest --cov=hamilton tests/ --ignore tests/integrations
+            .ci/test.sh
 
   pre-commit:
     docker:
@@ -113,69 +82,48 @@ jobs:
   dask-py36:
     docker:
       - image: circleci/python:3.6
-
+    environment:
+      TASK: dask
     steps:
       - checkout
       - run:
           name: install hamilton dependencies + dask
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -e ".[dask]"
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest graph_adapter_tests/h_dask
+            .ci/test.sh
   dask-py37:
     docker:
       - image: circleci/python:3.7
-
+    environment:
+      TASK: dask
     steps:
       - checkout
       - run:
           name: install hamilton dependencies + dask
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -e ".[dask]"
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest graph_adapter_tests/h_dask
+            .ci/test.sh
   ray-py37:
     docker:
       - image: circleci/python:3.7
-
+    environment:
+      TASK: ray
     steps:
       - checkout
       - run:
           name: install hamilton dependencies + ray
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -r requirements-test.txt
-            pip install -e ".[ray]"
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest graph_adapter_tests/h_ray
+            .ci/test.sh
   spark-py38:
     docker:
       - image: cimg/openjdk:14.0   # need java on it
@@ -205,104 +153,78 @@ jobs:
   integrations-py36:
     docker:
       - image: circleci/python:3.6
+    environment:
+      TASK: integrations
     steps:
       - checkout
       - run:
           name: install all python dependencies for integrations
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -e .[pandera] # TODO -- add more as we add more integrations
-            pip install -r requirements-test.txt
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest tests/integrations
+            .ci/test.sh
   integrations-py37:
     docker:
       - image: circleci/python:3.7
+    environment:
+      TASK: integrations
     steps:
       - checkout
       - run:
           name: install all python dependencies for integrations
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -e .[pandera] # TODO -- add more as we add more integrations
-            pip install -r requirements-test.txt
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest tests/integrations
+            .ci/test.sh
   integrations-py38:
     docker:
       - image: circleci/python:3.8
+    environment:
+      TASK: integrations
     steps:
       - checkout
       - run:
           name: install all python dependencies for integrations
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -e .[pandera] # TODO -- add more as we add more integrations
-            pip install -r requirements-test.txt
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest tests/integrations
+            .ci/test.sh
   integrations-py39:
     docker:
       - image: circleci/python:3.9
+    environment:
+      TASK: integrations
     steps:
       - checkout
       - run:
           name: install all python dependencies for integrations
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -e .[pandera] # TODO -- add more as we add more integrations
-            pip install -r requirements-test.txt
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest tests/integrations
+            .ci/test.sh
   asyncio-py39:
     docker:
       - image: circleci/python:3.9
+    environment:
+      TASK: async
     steps:
       - checkout
       - run:
           name: install hamilton dependencies + testing dependencies
           command: |
-            python -m venv venv || virtualenv venv
-            . venv/bin/activate
-            python --version
-            pip --version
-            pip install -e .
-            pip install -r graph_adapter_tests/h_async/requirements-test.txt
-
-      # run tests!
+            .ci/setup.sh
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            python -m pytest graph_adapter_tests/h_async
+            .ci/test.sh
 workflows:
   version: 2
   unit-test-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ jobs:
       task:
         type: string
     docker:
-      - image: circleci/python:<< parameters.python-version>>
+      - image: circleci/python:<< parameters.python-version >>
+    environment:
+      TASK: << parameters.task >>
     steps:
       - checkout
       - run:

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -31,7 +31,7 @@ from the command line.
 
 ### Running tests in Docker
 
-The most reliable to run `hamilton`'s unit tests is to simulate its continuous integration (CI) environment in docker.
+The most reliable way to run `hamilton`'s unit tests is to simulate its continuous integration (CI) environment in docker.
 
 `hamilton`'s CI logic is defined in shell scripts, whose behavior changes based on environment variable `TASK`.
 
@@ -74,7 +74,7 @@ additional arguments part, you'll then get verbose diffs if any tests fail.
 
 ### Using circle ci locally
 
-You need to install the circleci command line tooling for this to work. See the unit testing algo curriculum slides for details.
+You need to install the circleci command line tooling for this to work.
 Once you have installed it you just need to run `circleci local execute` from the root directory and it'll run the entire suite of tests
 that are setup to run each time you push a commit to a branch in github.
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -20,7 +20,6 @@ This repository is organized as follows:
 8. Push to github and create a PR.
 9. When you push to github circle ci will kick off unit tests and migration tests (for Stitch Fix users only).
 
-
 ## How to run unit tests
 
 You need to have installed the `requirements-test.txt` dependencies into the environment you're running for this to work. You can run tests two ways:
@@ -29,18 +28,46 @@ You need to have installed the `requirements-test.txt` dependencies into the env
 2. Using circle ci locally. The config for this lives in `.circleci/config.yml` which also shows commands to run tests
 from the command line.
 
+### Running tests in Docker
+
+The easiest way to run `hamilton`'s unit tests is to simulate its continuous integration (CI) environment in docker.
+
+`hamilton`'s CI logic is defined in shell scripts, whose behavior changes based on environment variable `TASK`.
+
+The following values for `TASK` are recognized:
+
+* `async` = unit tests using the async driver
+* `dask` = unit tests using the `dask` adapter
+* `integrations` = tests on integrations with other frameworks
+* `pre-commit` = static analysis (i.e. linting)
+* `pyspark` = unit tests using the `spark` adapter
+* `ray` = unit tests using the `ray` adapter
+* `tests` = core unit tests with minimal requirements
+
+Choose a Python version and task.
+
+```shell
+PYTHON_VERSION='3.8'
+TASK=tests
+```
+
+```shell
+docker run \
+  --rm \
+  --entrypoint="" \
+  -v "$(pwd)":/opt/testing \
+  --workdir /opt/testing \
+  --env TASK=${TASK} \
+  -it circleci/python:${PYTHON_VERSION} \
+  /bin/bash -c '.ci/setup.sh && .ci/test.sh'
+```
+
 ### Using pycharm to execute & debug unit tests
 
 You can debug and execute unit tests in pycharm easily. To set it up, you just hit `Edit configurations` and then
 add New > Python Tests > pytest. You then want to specify the `tests/` folder under `Script path`, and ensure the
 python environment executing it is the appropriate one with all the dependencies installed. If you add `-v` to the
 additional arguments part, you'll then get verbose diffs if any tests fail.
-
-### Using circle ci locally
-
-You need to install the circleci command line tooling for this to work. See the unit testing algo curriculum slides for details.
-Once you have installed it you just need to run `circleci local execute` from the root directory and it'll run the entire suite of tests
-that are setup to run each time you push a commit to a branch in github.
 
 # Pushing to pypi
 These are the steps to push to pypi. This is taken from the [python packaging tutorial](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives).

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -31,7 +31,7 @@ from the command line.
 
 ### Running tests in Docker
 
-The easiest way to run `hamilton`'s unit tests is to simulate its continuous integration (CI) environment in docker.
+The most reliable to run `hamilton`'s unit tests is to simulate its continuous integration (CI) environment in docker.
 
 `hamilton`'s CI logic is defined in shell scripts, whose behavior changes based on environment variable `TASK`.
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -20,6 +20,7 @@ This repository is organized as follows:
 8. Push to github and create a PR.
 9. When you push to github circle ci will kick off unit tests and migration tests (for Stitch Fix users only).
 
+
 ## How to run unit tests
 
 You need to have installed the `requirements-test.txt` dependencies into the environment you're running for this to work. You can run tests two ways:
@@ -68,6 +69,12 @@ You can debug and execute unit tests in pycharm easily. To set it up, you just h
 add New > Python Tests > pytest. You then want to specify the `tests/` folder under `Script path`, and ensure the
 python environment executing it is the appropriate one with all the dependencies installed. If you add `-v` to the
 additional arguments part, you'll then get verbose diffs if any tests fail.
+
+### Using circle ci locally
+
+You need to install the circleci command line tooling for this to work. See the unit testing algo curriculum slides for details.
+Once you have installed it you just need to run `circleci local execute` from the root directory and it'll run the entire suite of tests
+that are setup to run each time you push a commit to a branch in github.
 
 # Pushing to pypi
 These are the steps to push to pypi. This is taken from the [python packaging tutorial](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives).

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -52,6 +52,8 @@ PYTHON_VERSION='3.8'
 TASK=tests
 ```
 
+Then run the tests for that combination in a container.
+
 ```shell
 docker run \
   --rm \

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -75,6 +75,7 @@ additional arguments part, you'll then get verbose diffs if any tests fail.
 ### Using circle ci locally
 
 You need to install the circleci command line tooling for this to work.
+See https://circleci.com/docs/local-cli/ for details.
 Once you have installed it you just need to run `circleci local execute` from the root directory and it'll run the entire suite of tests
 that are setup to run each time you push a commit to a branch in github.
 


### PR DESCRIPTION
Fixes #114.

This PR proposes moving the logic currently contained in the project's CI (`.circleci/config.yml`) into shell scripts, for the reasons mentioned in #114:

* reduced code duplication across jobs
* reduced effort required to add, remove, and customize jobs
* lower-friction local develoopment

## Changes

* moves commands for CI jobs into 2 shell scripts
    - `.ci/setup.sh` = install dependencies used by every CI job
    - `.ci/test.sh` = install `hamilton`'s Python dependencies and run tests
* adds docs in `developer_setup.md` explaining how to re-use these scripts to run tests in Docker locally during development
* replaces uses of `apt install` with  `apt-get install`
* switches `pyspark` job to using a `circleci/python` image for consistency with all the other CI jobs + ease of use in development

## How I tested this

Ran `shellcheck` on the new scripts.

```shell
shellcheck .ci/setup.sh
shellcheck .ci/test.sh
```

Ran `yamllint` on the new CircleCI config.

```shell
yamllint .circleci/config.yml
```

Tried running some of the project's tests with different combinations of `TASK` and `PYTHON_VERSION`.

For example:

<details><summary>Dask tests on Python 3.9 (click me)</summary>

```shell
docker run \
  --rm \
  --entrypoint="" \
  -v "$(pwd)":/opt/testing \
  --workdir /opt/testing \
  --env TASK=dask \
  -it circleci/python:3.9 \
  /bin/bash -c '.ci/setup.sh && .ci/test.sh'
```

</details>

<details><summary>main tests on Python 3.10 (click me)</summary>

```shell
docker run \
  --rm \
  --entrypoint="" \
  -v "$(pwd)":/opt/testing \
  --workdir /opt/testing \
  --env TASK=tests \
  -it circleci/python:3.10 \
  /bin/bash -c '.ci/setup.sh && .ci/test.sh'
```

</details>


## Notes

References on re-using configuration in CircleCI configs:

* https://circleci.com/docs/reusing-config/
* https://circleci.com/docs/configuration-reference/#matrix
* https://circleci.com/docs/env-vars/

Reference on why `apt-get` is preferred to `apt` for things like CI scripts:

* https://askubuntu.com/a/829869

Thanks for your time and consideration.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
