### PR TITLE
PandasDataFrameResult: Convert non-list values to single row frame

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -166,12 +166,10 @@ class PandasDataFrameResult(ResultMixin):
             (value,) = outputs.values()  # this works because it's length 1.
             if isinstance(value, pd.DataFrame):
                 return value
-            elif isinstance(value, pd.Series):
-                return pd.DataFrame(outputs)
 
         if not any(pd.api.types.is_list_like(value) for value in outputs.values()):
-            # If we're dealing with all scalar values,
-            # coerce the output to a single-row, multi-column dataframe.
+            # If we're dealing with all values that don't have any "index" that could be created
+            # (i.e. scalars, objects) coerce the output to a single-row, multi-column dataframe.
             return pd.DataFrame([outputs])
 
         return pd.DataFrame(outputs)

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -169,7 +169,7 @@ class PandasDataFrameResult(ResultMixin):
             elif isinstance(value, pd.Series):
                 return pd.DataFrame(outputs)
 
-        if not any(isinstance(value, (pd.DataFrame, pd.Series)) for value in outputs.values()):
+        if not any(pd.api.types.is_list_like(value) for value in outputs.values()):
             # If we're dealing with all scalar values,
             # coerce the output to a single-row, multi-column dataframe.
             return pd.DataFrame([outputs])

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -168,7 +168,8 @@ class PandasDataFrameResult(ResultMixin):
                 return value
             elif isinstance(value, pd.Series):
                 return pd.DataFrame(outputs)
-            raise ValueError(f"Cannot build result. Cannot handle type {value}.")
+            else:
+                return pd.DataFrame([outputs])
         return pd.DataFrame(outputs)
 
 

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -168,8 +168,12 @@ class PandasDataFrameResult(ResultMixin):
                 return value
             elif isinstance(value, pd.Series):
                 return pd.DataFrame(outputs)
-            else:
-                return pd.DataFrame([outputs])
+
+        if not any(isinstance(value, (pd.DataFrame, pd.Series)) for value in outputs.values()):
+            # If we're dealing with all scalar values,
+            # coerce the output to a single-row, multi-column dataframe.
+            return pd.DataFrame([outputs])
+
         return pd.DataFrame(outputs)
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -235,7 +235,6 @@ def test_PandasDataFrameResult_build_result(outputs, expected_result):
         ({"a": [1, 2], "b": {"foo": "bar"}}),
         ({"a": [1, 2], "b": [3, 4, 5]}),
         ({"a": np.array([1, 2]), "b": np.array([3, 4, 5])}),
-        ({"a": np.array([1, 2]), "b": np.array([[3, 4], [5, 6]])}),
         ({"a": _gen_ints(3), "b": _gen_ints(4)}),
     ],
     ids=[
@@ -244,7 +243,6 @@ def test_PandasDataFrameResult_build_result(outputs, expected_result):
         "test-lists-and-dicts",
         "test-mismatched-lists",
         "test-mismatched-arrays",
-        "test-mismatched-dicts",
         "test-mismatched-generators",
     ],
 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -147,6 +147,7 @@ def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, 
                 {"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13]), "c": pd.Series([0, 1, 2])}
             ),
         ),
+        ({"a": 1}, pd.DataFrame([{"a": 1}])),
     ],
     ids=[
         "test-single-series",
@@ -154,6 +155,7 @@ def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, 
         "test-multiple-series",
         "test-multiple-series-with-scalar",
         "test-multiple-series-with-index",
+        "test-single-value",
     ],
 )
 def test_PandasDataFrameResult_build_result(outputs, expected_result):
@@ -166,7 +168,6 @@ def test_PandasDataFrameResult_build_result(outputs, expected_result):
 @pytest.mark.parametrize(
     "outputs",
     [
-        ({"a": 1}),
         (
             {
                 "a": pd.DataFrame({"a": [1, 2, 3], "b": [11, 12, 13]}),
@@ -182,7 +183,6 @@ def test_PandasDataFrameResult_build_result(outputs, expected_result):
         ),
     ],
     ids=[
-        "test-single-value",
         "test-multiple-dataframes",
         "test-multiple-series-with-dataframe",
     ],

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -122,11 +122,13 @@ def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, 
 @pytest.mark.parametrize(
     "outputs,expected_result",
     [
+        ({"a": 1}, pd.DataFrame([{"a": 1}])),
         ({"a": pd.Series([1, 2, 3])}, pd.DataFrame({"a": pd.Series([1, 2, 3])})),
         (
             {"a": pd.DataFrame({"a": [1, 2, 3], "b": [11, 12, 13]})},
             pd.DataFrame({"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13])}),
         ),
+        ({"a": 1, "bar": 2}, pd.DataFrame([{"a": 1, "bar": 2}])),
         (
             {"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13])},
             pd.DataFrame({"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13])}),
@@ -147,15 +149,15 @@ def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, 
                 {"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13]), "c": pd.Series([0, 1, 2])}
             ),
         ),
-        ({"a": 1}, pd.DataFrame([{"a": 1}])),
     ],
     ids=[
+        "test-single-scalar",
         "test-single-series",
         "test-single-dataframe",
+        "test-multiple-scalars",
         "test-multiple-series",
         "test-multiple-series-with-scalar",
         "test-multiple-series-with-index",
-        "test-single-value",
     ],
 )
 def test_PandasDataFrameResult_build_result(outputs, expected_result):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -121,8 +121,7 @@ def test_SimplePythonDataFrameGraphAdapter_check_input_type_mismatch(node_type, 
 
 def _gen_ints(n: int) -> typing.Iterator[int]:
     """Simple function to test that we can build results including generators."""
-    for i in range(n):
-        yield i
+    yield from range(n)
 
 
 class _Foo:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -125,6 +125,16 @@ def _gen_ints(n: int) -> typing.Iterator[int]:
         yield i
 
 
+class _Foo:
+    """Dummy object used for testing."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __eq__(self, other: typing.Any) -> bool:
+        return isinstance(other, _Foo) and other.name == self.name
+
+
 @pytest.mark.parametrize(
     "outputs,expected_result",
     [
@@ -138,6 +148,7 @@ def _gen_ints(n: int) -> typing.Iterator[int]:
         ({"a": np.array([1, 2, 3])}, pd.DataFrame({"a": pd.Series([1, 2, 3])})),
         ({"a": {"b": 1, "c": "foo"}}, pd.DataFrame({"a": {"b": 1, "c": "foo"}})),
         ({"a": _gen_ints(3)}, pd.DataFrame({"a": pd.Series([0, 1, 2])})),
+        ({"a": _Foo("bar")}, pd.DataFrame([{"a": _Foo("bar")}])),
         ({"a": 1, "bar": 2}, pd.DataFrame([{"a": 1, "bar": 2}])),
         (
             {"a": pd.Series([1, 2, 3]), "b": pd.Series([11, 12, 13])},
@@ -184,6 +195,12 @@ def _gen_ints(n: int) -> typing.Iterator[int]:
             pd.DataFrame({"a": pd.Series([1, 2, 3]), "b": pd.Series([4, 4, 4])}),
         ),
         (
+            {"a": {"foo": 1, "bar": 2}, "b": 4},
+            pd.DataFrame({"a": pd.Series([2, 1]), "b": pd.Series([4, 4])}).rename(
+                index=lambda i: ["bar", "foo"][i]
+            ),
+        ),
+        (
             {"a": pd.Series([1, 2, 3]), "b": pd.Series([4, 5, 6])},
             pd.DataFrame({"a": pd.Series([1, 2, 3]), "b": pd.Series([4, 5, 6])}),
         ),
@@ -196,6 +213,7 @@ def _gen_ints(n: int) -> typing.Iterator[int]:
         "test-single-array",
         "test-single-dict",
         "test-single-generator",
+        "test-single-object",
         "test-multiple-scalars",
         "test-multiple-series",
         "test-multiple-series-with-scalar",
@@ -206,6 +224,7 @@ def _gen_ints(n: int) -> typing.Iterator[int]:
         "test-multiple-generators",
         "test-scalar-and-series",
         "test-scalar-and-list",
+        "test-scalar-and-dict",
         "test-series-and-list",
     ],
 )


### PR DESCRIPTION
When trying to run an intermediate node which produces a scalar in the `hello_world` example, Hamilton throws an error:

```
WARNING:hamilton.base:It appears no Pandas index type was detected. This will likely break when trying to create a DataFrame. E.g. are you requesting all scalar values? Use a different result builder or return at least one Pandas object with an index. Ignore this warning if you're using DASK for now.
ERROR:hamilton.driver:-------------------------------------------------------------------
Oh no an error! Need help with Hamilton?
Join our slack and ask for help! https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg
-------------------------------------------------------------------

Traceback (most recent call last):
  File "my_script.py", line 29, in <module>
    df = dr.execute(output_columns)
  File "/Users/ian.hoffman/src/hamilton/examples/hello_world/.venv/lib/python3.8/site-packages/hamilton/driver.py", line 142, in execute
    raise e
  File "/Users/ian.hoffman/src/hamilton/examples/hello_world/.venv/lib/python3.8/site-packages/hamilton/driver.py", line 139, in execute
    return self.adapter.build_result(**outputs)
  File "/Users/ian.hoffman/src/hamilton/examples/hello_world/.venv/lib/python3.8/site-packages/hamilton/base.py", line 171, in build_result
    raise ValueError(f"Cannot build result. Cannot handle type {value}.")
ValueError: Cannot build result. Cannot handle type 28.333333333333332.
```

If we can run an entire DAG, it seems like we should be able to run any sub-DAG of the DAG.

## Changes

Updates `PandasDataFrameResult.build_result()` to convert scalar values into dataframes.

## How I tested this

Updated unit tests.

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.