### PR TITLE
Fixes does function wrapping #244

### DIFF
--- a/hamilton/function_modifiers.py
+++ b/hamilton/function_modifiers.py
@@ -744,7 +744,8 @@ class does(function_modifiers_base.NodeCreator):
         and the same parameters/types as the original function.
         """
 
-        def replacing_function(__fn=fn, **kwargs):
+        @functools.wraps(fn)
+        def wrapper_function(**kwargs):
             final_kwarg_values = {
                 key: param_spec.default
                 for key, param_spec in inspect.signature(fn).parameters.items()
@@ -754,7 +755,7 @@ class does(function_modifiers_base.NodeCreator):
             final_kwarg_values = does.map_kwargs(final_kwarg_values, self.argument_mapping)
             return self.replacing_function(**final_kwarg_values)
 
-        return node.Node.from_fn(fn).copy_with(callabl=replacing_function)
+        return node.Node.from_fn(fn).copy_with(callabl=wrapper_function)
 
 
 class dynamic_transform(function_modifiers_base.NodeCreator):

--- a/tests/resources/multiple_decorators_together.py
+++ b/tests/resources/multiple_decorators_together.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+from hamilton.function_modifiers import does, extract_columns
+
+
+def _sum_multiply(param0: int, param1: int, param2: int) -> pd.DataFrame:
+    return pd.DataFrame([{"param0a": param0, "param1b": param1, "param2c": param2}])
+
+
+@extract_columns("param1b")
+@does(_sum_multiply)
+def to_modify(param0: int, param1: int, param2: int = 2) -> pd.DataFrame:
+    """This sums the inputs it gets..."""
+    pass

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -367,7 +367,6 @@ def test_end_to_end_with_multiple_decorators():
     )
     nodes = fg.get_nodes()
     results = fg.execute(nodes, {}, {})
-    print(results)
     df_expected = tests.resources.multiple_decorators_together._sum_multiply(3, 1, 2)
     pd.testing.assert_series_equal(results["param1b"], df_expected["param1b"])
     pd.testing.assert_frame_equal(results["to_modify"], df_expected)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,6 +14,7 @@ import tests.resources.extract_column_nodes
 import tests.resources.extract_columns_execution_count
 import tests.resources.functions_with_generics
 import tests.resources.layered_decorators
+import tests.resources.multiple_decorators_together
 import tests.resources.optional_dependencies
 import tests.resources.parametrized_inputs
 import tests.resources.parametrized_nodes
@@ -357,6 +358,20 @@ def test_end_to_end_with_column_extractor_nodes():
     assert (
         nodes[0].documentation == "Function that should be parametrized to form multiple functions"
     )
+
+
+def test_end_to_end_with_multiple_decorators():
+    """Tests that a simple function graph with multiple decorators on a function works end-to-end"""
+    fg = graph.FunctionGraph(
+        tests.resources.multiple_decorators_together, config={"param0": 3, "param1": 1}
+    )
+    nodes = fg.get_nodes()
+    results = fg.execute(nodes, {}, {})
+    print(results)
+    df_expected = tests.resources.multiple_decorators_together._sum_multiply(3, 1, 2)
+    pd.testing.assert_series_equal(results["param1b"], df_expected["param1b"])
+    pd.testing.assert_frame_equal(results["to_modify"], df_expected)
+    assert nodes[0].documentation == "This sums the inputs it gets..."
 
 
 def test_end_to_end_with_config_modifier():


### PR DESCRIPTION
In issue #244 types were not being propagated of the function being wrapped.

This changes that by adding the functools.wraps decorator.

Adds a unit test to test for two decorators playing nice together and verified that it's broken before and fixed afterwards.


## Changes
- modifies `@does` wrapper function to properly emulate the signature of the function it is replacing.

## How I tested this
- locally
- unit test

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
