### PR TITLE
Adjusts index type check warnings

### DIFF
--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -133,8 +133,9 @@ class PandasDataFrameResult(ResultMixin):
             types_match = False
         elif number_with_indexes == 1 and no_index_length > 0:
             logger.warning(
-                f"WARNING: a single pandas index was found, but there are also {no_index_length} outputs without "
-                "an index. Please check whether the dataframe created matches what what you expect to happen."
+                f"WARNING: a single pandas index was found, but there are also {len(no_indexes['no-index'])} "
+                "outputs without an index. Please check whether the dataframe created matches what what you "
+                "expect to happen."
             )
             # Strictly speaking the index types match -- there is only one -- so setting to True.
             types_match = True

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -134,17 +134,15 @@ class PandasDataFrameResult(ResultMixin):
         elif number_with_indexes == 1 and no_index_length > 0:
             logger.warning(
                 f"WARNING: a single pandas index was found, but there are also {no_index_length} outputs without "
-                f"an index. Those values will be made constants throughout the values of the index."
+                "an index. Please check whether the dataframe created matches what what you expect to happen."
             )
             # Strictly speaking the index types match -- there is only one -- so setting to True.
             types_match = True
         # if all indexes matches no indexes
         elif no_index_length == all_indexes_length:
             logger.warning(
-                "It appears no Pandas index type was detected. This will likely break when trying to "
-                "create a DataFrame. E.g. are you requesting all scalar values? Use a different result "
-                "builder or return at least one Pandas object with an index. "
-                "Ignore this warning if you're using DASK for now."
+                "It appears no Pandas index type was detected (ignore this warning if you're using DASK for now.) "
+                "Please check whether the dataframe created matches what what you expect to happen."
             )
             types_match = False
         if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
Following #243 we need to adjust the warning
to make sense. Since we are not in danger of things breaking imminently. So the warning is just there for the user now to indicate how Pandas might be resolving indexes to create the dataframe.

## Changes
* adjusts logger warning message to now match behavior after #243 .

## How I tested this
* locally.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
