### PR TITLE
Adds telemetry

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -41,3 +41,6 @@ python --version
 echo "----- pip version -----"
 pip --version
 echo "-----------------------"
+
+# disable telemetry!
+export HAMILTON_TELEMETRY_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -257,6 +257,41 @@ If you are doing a lot of repetitive work, one might consider multiple cursors. 
 
 To use it hit `option + mouse click` to create multiple cursors. `Esc` to revert back to a normal mode.
 
+# Usage analytics & data privacy
+By default, when using Hamilton, it collects anonymous usage data to help improve Hamilton and know where to apply development
+efforts.
+
+We capture two events: one when the `Driver` object is instantiated, and one when the `execute()` call on the `Driver` object completes.
+No user data or potentially sensitive information is or ever will be collected. The captured data is limited to:
+
+* Operating System and Python version
+* A persistent UUID to indentify the session, stored in ~/.hamilton.conf.
+* Error stack trace limited to Hamilton code, if one occurs.
+* Information on what features you're using from Hamilton: decorators, adapters, result builders.
+* How Hamilton is being used: number of final nodes in DAG, number of modules, size of objects passed to `execute()`.
+
+If you're worried, see telemetry.py for details.
+
+If you do not wish to participate, one can opt-out with one of the following methods:
+1. Set it to false programmatically in your code before creating a Hamilton driver:
+   ```python
+   from hamilton import telemetry
+   telemetry.disable_telemetry()
+   ```
+2. Set the key `telemetry_enabled` to `false` in ~/.hamilton.conf under the `DEFAULT` section:
+   ```
+   [DEFAULT]
+   telemetry_enabled = True
+   ```
+3. Set HAMILTON_TELEMETRY_ENABLED=false as an environment variable. Either setting it for your shell session:
+   ```bash
+   export HAMILTON_TELEMETRY_ENABLED=false
+   ```
+   or passing it as part of the run command:
+   ```bash
+   HAMILTON_TELEMETRY_ENABLED=false python NAME_OF_MY_DRIVER.py
+   ```
+
 # Contributors
 
 ## Code Contributors

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ No user data or potentially sensitive information is or ever will be collected. 
 * A persistent UUID to indentify the session, stored in ~/.hamilton.conf.
 * Error stack trace limited to Hamilton code, if one occurs.
 * Information on what features you're using from Hamilton: decorators, adapters, result builders.
-* How Hamilton is being used: number of final nodes in DAG, number of modules, size of objects passed to `execute()`.
+* How Hamilton is being used: number of final nodes in DAG, number of modules, size of objects passed to `execute()`, the name of the Driver function being invoked.
 
 If you're worried, see telemetry.py for details.
 

--- a/examples/async/fastapi_example.py
+++ b/examples/async/fastapi_example.py
@@ -1,17 +1,23 @@
 import async_module
 import fastapi
 
+from hamilton import base
 from hamilton.experimental import h_async
 
 app = fastapi.FastAPI()
+
+# can instantiate a driver once for the life of the app:
+dr = h_async.AsyncDriver({}, async_module, result_builder=base.DictResult())
 
 
 @app.post("/execute")
 async def call(request: fastapi.Request) -> dict:
     """Handler for pipeline call"""
-    dr = h_async.AsyncDriver({}, async_module)
     input_data = {"request": request}
-    return await dr.raw_execute(["pipeline"], inputs=input_data)
+    # Can instantiate a driver within a request as well:
+    # dr = h_async.AsyncDriver({}, async_module, result_builder=base.DictResult())
+    result = await dr.execute(["pipeline"], inputs=input_data)
+    return result
 
 
 if __name__ == "__main__":

--- a/examples/async/requirements.txt
+++ b/examples/async/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp
-async
 fastapi
 sf-hamilton
 uvicorn

--- a/graph_adapter_tests/h_async/test_h_async.py
+++ b/graph_adapter_tests/h_async/test_h_async.py
@@ -66,7 +66,9 @@ async def test_driver_end_to_end():
 @mock.patch("hamilton.telemetry.g_telemetry_enabled", True)
 async def test_driver_end_to_end_telemetry(send_event_json):
     dr = h_async.AsyncDriver({}, simple_async_module, result_builder=base.DictResult())
-    all_vars = [var.name for var in dr.list_available_variables()]
+    with mock.patch("hamilton.telemetry.g_telemetry_enabled", False):
+        # don't count this telemetry tracking invocation
+        all_vars = [var.name for var in dr.list_available_variables()]
     result = await dr.execute(final_vars=all_vars, inputs={"external_input": 1})
     assert result == {
         "another_async_func": 8,

--- a/graph_adapter_tests/h_async/test_h_async.py
+++ b/graph_adapter_tests/h_async/test_h_async.py
@@ -78,6 +78,15 @@ async def test_driver_end_to_end_telemetry(send_event_json):
         "simple_async_func": 2,
         "simple_non_async_func": 7,
     }
-    await asyncio.sleep(1)  # to ensure the last telemetry invocation finishes executing
+    # to ensure the last telemetry invocation finishes executing
+    # get all tasks -- and the current task, and await all others.
+    try:
+        # only works for 3.7+
+        tasks = asyncio.all_tasks()
+        current_task = asyncio.current_task()
+        await asyncio.gather(*[t for t in tasks if t != current_task])
+    except AttributeError:
+        # required for 3.6
+        await asyncio.sleep(1)
     assert send_event_json.called
     assert len(send_event_json.call_args_list) == 2

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -13,7 +13,10 @@ import pandas as pd
 import typing_inspect
 from pandas.core.indexes import extension as pd_extension
 
-from . import node
+try:
+    from . import node
+except ImportError:
+    import node
 
 logger = logging.getLogger(__name__)
 

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -167,6 +167,10 @@ class FunctionGraph(object):
     def config(self):
         return self._config
 
+    @property
+    def decorator_counter(self) -> Dict[str, int]:
+        return fm_base.DECORATOR_COUNTER
+
     def get_nodes(self) -> List[node.Node]:
         return list(self.nodes.values())
 

--- a/hamilton/telemetry.py
+++ b/hamilton/telemetry.py
@@ -40,6 +40,7 @@ TRACK_URL = f"{HOST}/capture/"  # https://posthog.com/docs/api/post-only-endpoin
 API_KEY = "phc_mZg8bkn3yvMxqvZKRlMlxjekFU5DFDdcdAsijJ2EH5e"
 START_EVENT = "os_hamilton_run_start"
 END_EVENT = "os_hamilton_run_end"
+DRIVER_FUNCTION = "os_hamilton_driver_function_call"
 TIMEOUT = 2
 MAX_COUNT_SESSION = 1000
 
@@ -220,6 +221,25 @@ def create_end_event_json(
         "number_of_inputs": number_of_inputs,  # how many user provided things are there
         "driver_run_id": str(driver_run_id),  # let's tie this to a particular driver instantiation
         "error": error,  # if there was an error, what was the trace? (limited to Hamilton code)
+    }
+    event["properties"].update(payload)
+    return event
+
+
+def create_driver_function_invocation_event(function_name: str) -> dict:
+    """Function to create payload for tracking function name invocation.
+
+    :param function_name: the name of the driver function
+    :return: dict representing the JSON to send.
+    """
+    event = {
+        "api_key": API_KEY,
+        "event": DRIVER_FUNCTION,
+        "properties": {},
+    }
+    event["properties"].update(BASE_PROPERTIES)
+    payload = {
+        "function_name": function_name,  # what was the name of the driver function?
     }
     event["properties"].update(payload)
     return event

--- a/hamilton/telemetry.py
+++ b/hamilton/telemetry.py
@@ -1,0 +1,339 @@
+"""
+This module contains code that relates to sending Hamilton usage telemetry.
+
+To disable sending telemetry there are three ways:
+
+1. Set it to false programmatically in your driver:
+  >>> from hamilton import telemetry
+  >>> telemetry.disable_telemetry()
+2. Set it to `false` in ~/.hamilton.conf under `DEFAULT`
+  [DEFAULT]
+  telemetry_enabled = True
+3. Set HAMILTON_TELEMETRY_ENABLED=false as an environment variable:
+  HAMILTON_TELEMETRY_ENABLED=false python run.py
+  or:
+  export HAMILTON_TELEMETRY_ENABLED=false
+"""
+import configparser
+import json
+import logging
+import os
+import platform
+import threading
+import traceback
+import uuid
+from typing import Dict, Optional
+from urllib import request
+
+try:
+    from . import base
+    from .version import VERSION
+except ImportError:
+    import base
+    from version import VERSION
+
+logger = logging.getLogger(__name__)
+
+STR_VERSION = ".".join([str(i) for i in VERSION])
+HOST = "https://app.posthog.com"
+TRACK_URL = f"{HOST}/capture/"  # https://posthog.com/docs/api/post-only-endpoints
+API_KEY = "phc_mZg8bkn3yvMxqvZKRlMlxjekFU5DFDdcdAsijJ2EH5e"
+START_EVENT = "os_hamilton_run_start"
+END_EVENT = "os_hamilton_run_end"
+TIMEOUT = 2
+MAX_COUNT_SESSION = 1000
+
+DEFAULT_CONFIG_LOCATION = os.path.expanduser("~/.hamilton.conf")
+
+
+def _load_config(config_location: str) -> configparser.ConfigParser:
+    """Pulls config. Gets/sets default anonymous ID.
+
+    Creates the anonymous ID if it does not exist, writes it back if so.
+    :param config_location: location of the config file.
+    """
+    config = configparser.ConfigParser()
+    try:
+        with open(config_location) as f:
+            config.read_file(f)
+    except Exception:
+        config["DEFAULT"] = {}
+    else:
+        if "DEFAULT" not in config:
+            config["DEFAULT"] = {}
+
+    if "anonymous_id" not in config["DEFAULT"]:
+        config["DEFAULT"]["anonymous_id"] = str(uuid.uuid4())
+        try:
+            with open(config_location, "w") as f:
+                config.write(f)
+        except Exception:
+            pass
+    return config
+
+
+def _check_config_and_environ_for_telemetry_flag(
+    telemetry_default: bool, config_obj: configparser.ConfigParser
+):
+    """Checks the config and environment variables for the telemetry value.
+
+    Note: the environment variable has greater precedence than the config value.
+    """
+    telemetry_enabled = telemetry_default
+    if "telemetry_enabled" in config_obj["DEFAULT"]:
+        try:
+            telemetry_enabled = config_obj.getboolean("DEFAULT", "telemetry_enabled")
+        except ValueError as e:
+            logger.debug(
+                "Unable to parse value for `telemetry_enabled` from config. " f"Encountered {e}"
+            )
+    if os.environ.get("HAMILTON_TELEMETRY_ENABLED") is not None:
+        env_value = os.environ.get("HAMILTON_TELEMETRY_ENABLED")
+        # set the value
+        config_obj["DEFAULT"]["telemetry_enabled"] = env_value
+        try:
+            telemetry_enabled = config_obj.getboolean("DEFAULT", "telemetry_enabled")
+        except ValueError as e:
+            logger.debug(
+                "Unable to parse value for `HAMILTON_TELEMETRY_ENABLED` from environment. "
+                f"Encountered {e}"
+            )
+    return telemetry_enabled
+
+
+config = _load_config(DEFAULT_CONFIG_LOCATION)
+g_telemetry_enabled = _check_config_and_environ_for_telemetry_flag(True, config)
+g_anonymous_id = config["DEFAULT"]["anonymous_id"]
+call_counter = 0
+
+
+def disable_telemetry():
+    """Disables telemetry tracking."""
+    global g_telemetry_enabled
+    g_telemetry_enabled = False
+
+
+def is_telemetry_enabled() -> bool:
+    """Returns whether telemetry tracking is enabled or not.
+
+    Increments a counter to stop sending telemetry after 1000 invocations.
+    """
+    if g_telemetry_enabled:
+        global call_counter
+        call_counter += 1
+        if call_counter > MAX_COUNT_SESSION:
+            # we have hit our limit -- disable telemetry.
+            return False
+        return True
+    else:
+        return False
+
+
+# base properties to instantiate on module load.
+BASE_PROPERTIES = {
+    "os_type": os.name,
+    "os_version": platform.platform(),
+    "python_version": f"{platform.python_version()}/{platform.python_implementation()}",
+    "distinct_id": g_anonymous_id,
+    "hamilton_version": list(VERSION),
+    "telemetry_version": "0.0.1",
+}
+
+
+def create_start_event_json(
+    number_of_nodes: int,
+    number_of_modules: int,
+    number_of_config_items: int,
+    decorators_used: Dict[str, int],
+    graph_adapter_used: str,
+    result_builder_used: str,
+    driver_run_id: uuid.UUID,
+    error: Optional[str],
+):
+    """Creates the start event JSON.
+
+    The format we want to follow is the one for [post-hog](# https://posthog.com/docs/api/post-only-endpoints).
+
+    :param number_of_nodes: the number of nodes in the graph
+    :param number_of_modules: the number of modules parsed
+    :param number_of_config_items: the number of items in configuration
+    :param decorators_used: a dict of decorator -> count
+    :param graph_adapter_used: the name of the graph adapter used
+    :param result_builder_used: the name of the result builder used
+    :param driver_run_id: the ID of the run
+    :param error: an error string if any
+    :return: dictionary to send.
+    """
+    event = {
+        "api_key": API_KEY,
+        "event": START_EVENT,
+        "properties": {},
+    }
+    event["properties"].update(BASE_PROPERTIES)
+    payload = {
+        "number_of_nodes": number_of_nodes,  # approximately how many nodes were in the DAG?
+        "number_of_modules": number_of_modules,  # approximately how many modules were used?
+        "number_of_config_items": number_of_config_items,  # how many configs are people passing in?
+        "decorators_used": decorators_used,  # what decorators were used, and how many times?
+        "graph_adapter_used": graph_adapter_used,  # what was the graph adapter used?
+        "result_builder_used": result_builder_used,  # what was the result builder used?
+        "driver_run_id": str(driver_run_id),  # was this a new driver object? or?
+        "error": error,  # if there was an error, what was the trace? (limited to Hamilton code)
+    }
+    event["properties"].update(payload)
+    return event
+
+
+def create_end_event_json(
+    is_success: bool,
+    runtime_seconds: float,
+    number_of_outputs: int,
+    number_of_overrides: int,
+    number_of_inputs: int,
+    driver_run_id: uuid.UUID,
+    error: Optional[str],
+):
+    """Creates the end event JSON.
+
+    The format we want to follow is the one for [post-hog](# https://posthog.com/docs/api/post-only-endpoints).
+
+    :param is_success: whether execute was successful
+    :param runtime_seconds: how long execution took
+    :param number_of_outputs: the number of outputs requested
+    :param number_of_overrides: the number of overrides provided
+    :param number_of_inputs: the number of inputs provided
+    :param driver_run_id: the run ID of this driver run
+    :param error: the error string if any
+    :return: dictionary to send.
+    """
+    event = {
+        "api_key": API_KEY,
+        "event": END_EVENT,
+        "properties": {},
+    }
+    event["properties"].update(BASE_PROPERTIES)
+    payload = {
+        "is_success": is_success,  # was this run successful?
+        "runtime_seconds": runtime_seconds,  # how long did it take
+        "number_of_outputs": number_of_outputs,  # how many outputs were requested
+        "number_of_overrides": number_of_overrides,  # how many outputs were requested
+        "number_of_inputs": number_of_inputs,  # how many user provided things are there
+        "driver_run_id": str(driver_run_id),  # let's tie this to a particular driver instantiation
+        "error": error,  # if there was an error, what was the trace? (limited to Hamilton code)
+    }
+    event["properties"].update(payload)
+    return event
+
+
+def _send_event_json(event_json: dict):
+    """Internal function to send the event JSON to posthog.
+
+    :param event_json: the dictionary of data to JSON serialize and send
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "TODO",
+        "User-Agent": f"hamilton/{STR_VERSION}",
+    }
+    try:
+        data = json.dumps(event_json).encode()
+        req = request.Request(TRACK_URL, data=data, headers=headers)
+        with request.urlopen(req, timeout=TIMEOUT) as f:
+            res = f.read()
+            if f.code != 200:
+                raise RuntimeError(res)
+    except Exception as e:
+        if logger.isEnabledFor(logging.DEBUG):
+            logging.debug(f"Failed to send telemetry data: {e}")
+    else:
+        if logger.isEnabledFor(logging.DEBUG):
+            logging.debug(f"Succeed in sending telemetry consisting of [{data}].")
+
+
+def send_event_json(event_json: dict):
+    """Sends the event json in its own thread.
+
+    :param event_json: the data to send
+    """
+    if not g_telemetry_enabled:
+        raise RuntimeError("Won't send; tracking is disabled!")
+    try:
+        th = threading.Thread(target=_send_event_json, args=(event_json,))
+        th.start()
+    except Exception as e:
+        # capture any exception!
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Encountered error while sending event JSON via it's own thread:\n{e}")
+
+
+def sanitize_error(exc_type, exc_value, exc_traceback) -> str:
+    """Sanitizes an incoming error and pulls out a string to tell us where it came from.
+
+    :param exc_type: pulled from `sys.exc_info()`
+    :param exc_value: pulled from `sys.exc_info()`
+    :param exc_traceback: pulled from `sys.exc_info()`
+    :return: string to use for telemetry
+    """
+    try:
+        te = traceback.TracebackException(exc_type, exc_value, exc_traceback, limit=-5)
+        sanitized_string = ""
+        for stack_item in te.stack:
+            stack_file_path = stack_item.filename.split(os.sep)
+            # take last 4 places only -- that's how deep hamilton is.
+            stack_file_path = stack_file_path[-4:]
+            try:
+                # find first occurrence
+                index = stack_file_path.index("hamilton")
+            except ValueError:
+                sanitized_string += "...<USER_CODE>...\n"
+                continue
+            file_name = "..." + "/".join(stack_file_path[index:])
+            sanitized_string += f"{file_name}, line {stack_item.lineno}, in {stack_item.name}\n"
+        return sanitized_string
+    except Exception as e:
+        # we don't want this to fail
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Encountered exception sanitizing error. Got:\n{e}")
+        return "FAILED_TO_SANITIZE_ERROR"
+
+
+def get_adapter_name(adapter: base.HamiltonGraphAdapter) -> str:
+    """Get the class name of the `hamilton` adapter used.
+
+    If we detect it's not a Hamilton one, we do not track it.
+
+    :param adapter: base.HamiltonGraphAdapter object.
+    :return: string modeul + class name of the adapter.
+    """
+    # Check whether it's a hamilton based adapter
+    if adapter.__module__.startswith("hamilton."):
+        adapter_name = f"{adapter.__module__}.{adapter.__class__.__name__}"
+    else:
+        adapter_name = "custom_adapter"
+    return adapter_name
+
+
+def get_result_builder_name(adapter: base.HamiltonGraphAdapter) -> str:
+    """Get the class name of the `hamilton` result builder used.
+
+    If we detect it's not a base one, we do not track it.
+
+    :param adapter: base.HamiltonGraphAdapter object.
+    :return: string module + class name of the result builder.
+    """
+    class_to_inspect = adapter
+    # if there is an attribute, get that out to use as the class to inspect
+    if hasattr(adapter, "result_builder"):
+        class_to_inspect = getattr(adapter, "result_builder")
+    # Go by class itself
+    if isinstance(class_to_inspect, base.StrictIndexTypePandasDataFrameResult):
+        result_builder_name = "hamilton.base.StrictIndexTypePandasDataFrameResult"
+    elif isinstance(class_to_inspect, base.PandasDataFrameResult):
+        result_builder_name = "hamilton.base.PandasDataFrameResult"
+    elif isinstance(class_to_inspect, base.DictResult):
+        result_builder_name = "hamilton.base.DictResult"
+    elif isinstance(class_to_inspect, base.NumpyMatrixResult):
+        result_builder_name = "hamilton.base.NumpyMatrixResult"
+    else:
+        result_builder_name = "custom_builder"
+    return result_builder_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+from hamilton import telemetry
+
+# disable telemetry for all tests!
+telemetry.disable_telemetry()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,193 @@
+import configparser
+import os
+import sys
+import uuid
+from unittest import mock
+
+import pytest
+
+from hamilton import base, telemetry
+from hamilton.experimental import h_async
+
+
+@pytest.fixture
+def blank_conf_file(tmp_path_factory):
+    """Fixture to load config file without an ID"""
+    file_location = tmp_path_factory.mktemp("home") / "hamilton.conf"
+    with open(file_location, "w") as conf_file:
+        conf = configparser.ConfigParser()
+        conf.write(conf_file)
+    return file_location
+
+
+@pytest.fixture
+def existing_conf_file(tmp_path_factory):
+    """Fixture to load config file with an ID"""
+    file_location = tmp_path_factory.mktemp("home") / "hamilton.conf"
+    with open(file_location, "w") as conf_file:
+        conf = configparser.ConfigParser()
+        conf["DEFAULT"]["anonymous_id"] = "testing123-id"
+        conf.write(conf_file)
+    return file_location
+
+
+def test__load_config_exists_with_id(existing_conf_file):
+    """Tests loading a config that has an ID."""
+    config = telemetry._load_config(existing_conf_file)
+    a_id = config["DEFAULT"]["anonymous_id"]
+    assert a_id == "testing123-id"
+
+
+def test__load_config_exists_without_id(blank_conf_file):
+    """Tests load from existing file without an ID."""
+    config = telemetry._load_config(blank_conf_file)
+    a_id = config["DEFAULT"]["anonymous_id"]
+    assert str(uuid.UUID(a_id, version=4)) == a_id
+    # check it was written back
+    with open(blank_conf_file, "r") as conf_file:
+        actual_config = configparser.ConfigParser()
+        actual_config.read_file(conf_file)
+    assert a_id == actual_config["DEFAULT"]["anonymous_id"]
+
+
+def test__load_config_new(tmp_path_factory):
+    """Tests no config file existing and one being created."""
+    file_location = tmp_path_factory.mktemp("home") / "hamilton123.conf"
+    config = telemetry._load_config(file_location)
+    a_id = config["DEFAULT"]["anonymous_id"]
+    assert str(uuid.UUID(a_id, version=4)) == a_id
+    # check it was written back
+    with open(file_location, "r") as conf_file:
+        actual_config = configparser.ConfigParser()
+        actual_config.read_file(conf_file)
+    assert a_id == actual_config["DEFAULT"]["anonymous_id"]
+
+
+def test__check_config_and_environ_for_telemetry_flag_not_present():
+    """Tests not present in both."""
+    conf = configparser.ConfigParser()
+    actual = telemetry._check_config_and_environ_for_telemetry_flag(False, conf)
+    assert actual is False
+
+
+def test__check_config_and_environ_for_telemetry_flag_in_config():
+    """tests getting from config."""
+    conf = configparser.ConfigParser()
+    conf["DEFAULT"]["telemetry_enabled"] = "tRuE"
+    actual = telemetry._check_config_and_environ_for_telemetry_flag(False, conf)
+    assert actual is True
+
+
+@mock.patch.dict(os.environ, {"HAMILTON_TELEMETRY_ENABLED": "TrUe"})
+def test__check_config_and_environ_for_telemetry_flag_in_env():
+    """tests getting from env."""
+    conf = configparser.ConfigParser()
+    actual = telemetry._check_config_and_environ_for_telemetry_flag(False, conf)
+    assert actual is True
+
+
+@mock.patch.dict(os.environ, {"HAMILTON_TELEMETRY_ENABLED": "TrUe"})
+def test__check_config_and_environ_for_telemetry_flag_env_overrides():
+    """tests that env overrides the config."""
+    conf = configparser.ConfigParser()
+    conf["DEFAULT"]["telemetry_enabled"] = "FALSE"
+    actual = telemetry._check_config_and_environ_for_telemetry_flag(False, conf)
+    assert actual is True
+
+
+def test_sanitize_error_general():
+    """Tests sanitizing code in the general case.
+
+    Run this test how circleci runs it.
+
+    It's too hard to test code that isn't in the repo, or at least it hasn't occurred to
+    me how to mock it easily.
+    """
+    try:
+        # make a call in a hamilton module to mimic something from hamilton
+        # but the stack trace should block the stack call from this function.
+        telemetry.get_adapter_name(None)
+    except AttributeError:
+        actual = telemetry.sanitize_error(*sys.exc_info())
+        # this strips the full path -- note: line changes in telemetry.py will change this...
+        expected = (
+            """...<USER_CODE>...\n...hamilton/telemetry.py, line 309, in get_adapter_name\n"""
+        )
+        # if this fails -- run it how circleci runs it
+        assert actual == expected
+
+
+# classes for the tests below
+class CustomAdapter(base.HamiltonGraphAdapter):
+    def __init__(self, result_builder: base.ResultMixin):
+        self.result_builder = result_builder
+
+
+class CustomResultBuilder(base.ResultMixin):
+    pass
+
+
+@pytest.mark.parametrize(
+    "adapter, expected",
+    [
+        (
+            base.SimplePythonDataFrameGraphAdapter(),
+            "hamilton.base.SimplePythonDataFrameGraphAdapter",
+        ),
+        (
+            base.SimplePythonGraphAdapter(base.DictResult()),
+            "hamilton.base.SimplePythonGraphAdapter",
+        ),
+        (
+            h_async.AsyncGraphAdapter(base.DictResult()),
+            "hamilton.experimental.h_async.AsyncGraphAdapter",
+        ),
+        (CustomAdapter(base.DictResult()), "custom_adapter"),
+    ],
+)
+def test_get_adapter_name(adapter, expected):
+    """Tests get_adapter_name"""
+    actual = telemetry.get_adapter_name(adapter)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "adapter, expected",
+    [
+        (base.SimplePythonDataFrameGraphAdapter(), "hamilton.base.PandasDataFrameResult"),
+        (base.SimplePythonGraphAdapter(base.DictResult()), "hamilton.base.DictResult"),
+        (
+            base.SimplePythonGraphAdapter(base.NumpyMatrixResult()),
+            "hamilton.base.NumpyMatrixResult",
+        ),
+        (
+            base.SimplePythonGraphAdapter(base.StrictIndexTypePandasDataFrameResult()),
+            "hamilton.base.StrictIndexTypePandasDataFrameResult",
+        ),
+        (base.SimplePythonGraphAdapter(CustomResultBuilder()), "custom_builder"),
+        (h_async.AsyncGraphAdapter(base.DictResult()), "hamilton.base.DictResult"),
+        (CustomAdapter(base.DictResult()), "hamilton.base.DictResult"),
+        (CustomAdapter(CustomResultBuilder()), "custom_builder"),
+    ],
+)
+def test_get_result_builder_name(adapter, expected):
+    """Tests getting the result builder name"""
+    actual = telemetry.get_result_builder_name(adapter)
+    assert actual == expected
+
+
+def test_is_telemetry_enabled_false():
+    """Tests that we don't increment the counter when we're disabled."""
+    before = telemetry.call_counter
+    telemetry_enabled = telemetry.is_telemetry_enabled()
+    assert telemetry.call_counter == before
+    assert telemetry_enabled is False
+
+
+@mock.patch("hamilton.telemetry.g_telemetry_enabled", True)
+def test_is_telemetry_disabled_true():
+    """Tests that we do increment the counter when we're enabled."""
+    before = telemetry.call_counter
+    telemetry_enabled = telemetry.is_telemetry_enabled()
+    assert telemetry.call_counter == before + 1
+    assert telemetry_enabled is True

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -110,8 +110,12 @@ def test_sanitize_error_general():
     except AttributeError:
         actual = telemetry.sanitize_error(*sys.exc_info())
         # this strips the full path -- note: line changes in telemetry.py will change this...
+        # so replace with line XXX
+        import re
+
+        actual = re.sub(r"line \d\d\d", "line XXX", actual)
         expected = (
-            """...<USER_CODE>...\n...hamilton/telemetry.py, line 309, in get_adapter_name\n"""
+            """...<USER_CODE>...\n...hamilton/telemetry.py, line XXX, in get_adapter_name\n"""
         )
         # if this fails -- run it how circleci runs it
         assert actual == expected


### PR DESCRIPTION
This adds telemetry capture to Hamilton.

After this change, by default, when using Hamilton, it will collect anonymous usage data to help us improve Hamilton and know where to apply development efforts.

We capture two events: one when a driver object is instantiated, and one when the `execute()` call on the driver completes.
No user data or potentially sensitive information is or ever will be collected. The captured data is limited to:

* Operating System and Python version
* A persistent UUID to indentify the session, stored in ~/.hamilton.conf. 
* Error stack trace limited to Hamilton code, if one occurs.
* Information on what features you're using from Hamilton: decorators, adapters, result builders.
* How Hamilton is being used: number of final nodes in DAG, number of modules, size of objects passed to `execute()`. 

If you do not wish to participate, one can opt-out with one of the following methods:
1. Set it to false programmatically in your code before creating a Hamilton driver:
   ```python
   from hamilton import telemetry
   telemetry.disable_telemetry()
   ```
2. Set the key `telemetry_enabled` to `false` in ~/.hamilton.conf under the `DEFAULT` section:
   ```
   [DEFAULT]
   telemetry_enabled = True
   ```
3. Set HAMILTON_TELEMETRY_ENABLED=false as an environment variable. Either setting it for your shell session:
   ```bash
   export HAMILTON_TELEMETRY_ENABLED=false
   ```
   or passing it as part of the run command:
   ```bash
   HAMILTON_TELEMETRY_ENABLED=false python NAME_OF_MY_DRIVER.py 
   ```

-------
## Changes
 - adds telemetry.py
 - adds code to driver.Driver to capture telemetry
 - the code should be wrapped in enough try excepts that it should not impact running operations
 - adds code to function_modifiers base.
 - adds tests 

## How I tested this
Tested this locally, and added unit tests.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
