### PR TITLE
[ci] remove 'test_suite' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
-    test_suite="tests",
     # Note that this feature requires pep8 >= v9 and a version of setup tools greater than the
     # default version installed with virtualenv. Make sure to update your tools!
     python_requires=">=3.6, <4",


### PR DESCRIPTION
## Changes

* removes unnecessary argument `test_suite` in `setuptools.setup()` in `setup.py`

## How I tested this

```shell
docker run \
  --rm \
  --entrypoint="" \
  -v "$(pwd)":/opt/testing \
  --workdir /opt/testing \
  --env TASK=tests \
  -it circleci/python:3.9 \
  /bin/bash -c '.ci/setup.sh && .ci/test.sh'
```

Saw that test collection succeeded and all tests ran successfully.

```text
===== 355 passed, 1 warning in 4.87s ====
```

## Notes

This project uses `pytest` directly, and doesn't need any of the configuration for `python setup.py test`.

This change reduces the risk of `hamilton` packaging and installation failing on future versions of `setuptools` which remove `python setup.py test`  support completely.

See relate PR #89 for links to documentation on ongoing changes to `setuptools`.

Thanks for your time and consideration.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
