### PR TITLE
Polars example

### DIFF
--- a/examples/polars/README.md
+++ b/examples/polars/README.md
@@ -1,0 +1,23 @@
+# Classic Hamilton Hello World
+
+In this example we show you how to create a simple hello world dataflow that
+creates a polars dataframe as a result. It performs a series of transforms on the
+input to create columns that appear in the output.
+
+File organization:
+
+* `my_functions.py` houses the logic that we want to compute.
+Note (1) how the functions are named, and what input
+parameters they require. That is how we create a DAG modeling the dataflow we want to happen.
+Note (2) that we have a custom extract_columns decorator there for now. This is because we don't have
+a way to parameterize the dataframe library for the extract_columns function yet. This will be fixed in the future.
+* `my_script.py` houses how to get Hamilton to create the DAG, specifying that we want a polars dataframe and
+exercise it with some inputs.
+
+To run things:
+```bash
+> python my_script.py
+```
+
+If you have questions, or need help with this example,
+join us on [slack](https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg), and we'll try to help!

--- a/examples/polars/my_functions.py
+++ b/examples/polars/my_functions.py
@@ -3,7 +3,7 @@ import polars as pl
 from hamilton.function_modifiers import extract_columns
 
 
-@extract_columns("signups", "spend", df_type=pl.DataFrame, series_type=pl.Series)
+@extract_columns("signups", "spend")  # , df_type=pl.DataFrame, series_type=pl.Series)
 def base_df(base_df_location: str) -> pl.DataFrame:
     """Loads base dataframe of data.
 

--- a/examples/polars/my_functions.py
+++ b/examples/polars/my_functions.py
@@ -1,0 +1,48 @@
+import polars as pl
+
+from hamilton.function_modifiers import extract_columns
+
+
+@extract_columns("signups", "spend", df_type=pl.DataFrame, series_type=pl.Series)
+def base_df(base_df_location: str) -> pl.DataFrame:
+    """Loads base dataframe of data.
+
+    :param base_df_location: just showing that we could load this from a file...
+    :return:
+    """
+    return pl.DataFrame(
+        {
+            "signups": pl.Series([1, 10, 50, 100, 200, 400]),
+            "spend": pl.Series([10, 10, 20, 40, 40, 50]),
+        }
+    )
+
+
+def avg_3wk_spend(spend: pl.Series) -> pl.Series:
+    """Rolling 3 week average spend."""
+    return spend.rolling_mean(3)
+
+
+def spend_per_signup(spend: pl.Series, signups: pl.Series) -> pl.Series:
+    """The cost per signup in relation to spend."""
+    return spend / signups
+
+
+def spend_mean(spend: pl.Series) -> float:
+    """Shows function creating a scalar. In this case it computes the mean of the entire column."""
+    return spend.mean()
+
+
+def spend_zero_mean(spend: pl.Series, spend_mean: float) -> pl.Series:
+    """Shows function that takes a scalar. In this case to zero mean spend."""
+    return spend - spend_mean
+
+
+def spend_std_dev(spend: pl.Series) -> float:
+    """Function that computes the standard deviation of the spend column."""
+    return spend.std()
+
+
+def spend_zero_mean_unit_variance(spend_zero_mean: pl.Series, spend_std_dev: float) -> pl.Series:
+    """Function showing one way to make spend have zero mean and unit variance."""
+    return spend_zero_mean / spend_std_dev

--- a/examples/polars/my_script.py
+++ b/examples/polars/my_script.py
@@ -1,0 +1,55 @@
+import logging
+import sys
+from typing import Dict
+
+import polars as pl
+
+from hamilton import base, driver
+
+logging.basicConfig(stream=sys.stdout)
+
+
+class PolarsDataFrameResult(base.ResultMixin):
+    """We need to create a result builder for our use case. Hamilton doesn't have a standard one
+    to use just yet. If you think it should -- let's chat and figure out a way to make it happen!
+    """
+
+    def build_result(self, **outputs: Dict[str, pl.Series]) -> pl.DataFrame:
+        """This is the method that Hamilton will call to build the final result. It will pass in the results
+        of the requested outputs that you passed in to the execute() method.
+        :param outputs: The results of the requested outputs.
+        :return: a polars DataFrame.
+        """
+        if len(outputs) == 1:
+            (value,) = outputs.values()  # this works because it's length 1.
+            if isinstance(value, pl.DataFrame):  # it's a dataframe
+                return value
+            elif not isinstance(value, pl.Series):  # it's a single scalar
+                return pl.DataFrame([outputs])
+        # TODO: check for length of outputs and determine what should
+        # happen for mixed outputs that include scalars for example.
+        return pl.DataFrame(outputs)
+
+
+adapter = base.SimplePythonGraphAdapter(result_builder=PolarsDataFrameResult())
+config = {
+    "base_df_location": "dummy_value",
+}
+import my_functions  # where our functions are defined
+
+dr = driver.Driver(config, my_functions, adapter=adapter)
+# note -- we cannot request scalar outputs like we could do with Pandas.
+output_columns = [
+    "spend",
+    "signups",
+    "avg_3wk_spend",
+    "spend_per_signup",
+    "spend_zero_mean_unit_variance",
+]
+# let's create the dataframe!
+df = dr.execute(output_columns)
+print(df)
+
+# To visualize do `pip install sf-hamilton[visualization]` if you want these to work
+# dr.visualize_execution(output_columns, './my_dag.dot', {})
+# dr.display_all_functions('./my_full_dag.dot')

--- a/examples/polars/requirements.txt
+++ b/examples/polars/requirements.txt
@@ -1,0 +1,2 @@
+polars
+sf-hamilton

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -374,9 +374,6 @@ class extract_columns(base.NodeExpander):
                         df_generated[col] = self.fill_with
             return df_generated
 
-        # manually add the type annotation
-        df_generator.__annotations__["return"] = self.df_type
-
         output_nodes = [node_.copy_with(callabl=df_generator)]
 
         for column in self.columns:
@@ -395,16 +392,13 @@ class extract_columns(base.NodeExpander):
                     )
                 return kwargs[node_.name][column_to_extract]
 
-            # manually add the type annotation
-            extractor_fn.__annotations__["return"] = self.series_type
-
             output_nodes.append(
                 node.Node(
                     column,
-                    self.series_type,
+                    self.series_type,  # set output type here
                     doc_string,
                     extractor_fn,
-                    input_types={node_.name: self.df_type},
+                    input_types={node_.name: self.df_type},  # set input type requirement here
                     tags=node_.tags.copy(),
                 )
             )


### PR DESCRIPTION
Polars is gaining traction, we should have an example. This PR helps show an example that matches our hello world. It requires one adjust to the `extract_columns` decorator to function. Otherwise the user right now has to create their own build result function. Which seems fine for now, but it's something we could build a `sf-hamilton-polars` package for to house.

## Changes
1. prototypes change to extract_columns to handle providing the dataframe types.
2. adds example polars code.

## How I tested this
1. Tested this locally.

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
