### PR TITLE
Adds 3.10 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,10 @@ workflows:
           python-version: '3.9'
           task: tests
       - test:
+          name: build-py310
+          python-version: '3.10'
+          task: tests
+      - test:
           name: pre-commit
           python-version: '3.9'
           task: pre-commit
@@ -74,6 +78,14 @@ workflows:
           python-version: '3.9'
           task: integrations
       - test:
+          name: integrations-py310
+          python-version: '3.10'
+          task: integrations
+      - test:
           name: asyncio-py39
           python-version: '3.9'
+          task: async
+      - test:
+          name: asyncio-py310
+          python-version: '3.10'
           task: async

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <a href="https://join.slack.com/t/hamilton-opensource/shared_invite/zt-1bjs72asx-wcUTgH7q7QX1igiQ5bbdcg" target="_blank"><img src="https://img.shields.io/badge/Join-Hamilton_Slack-brightgreen?logo=slack" alt="Hamilton Slack"/></a>
         <a href="https://twitter.com/hamilton_os" target="_blank"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social" alt="Twitter"/></a>
         <br/>
-    <a href="https://www.python.org/downloads/" target="_blank"><img src="https://img.shields.io/badge/python-3.6%20|%203.7|%203.8|%203.9-brightgreen.svg" alt="Python supported"/></a>
+    <a href="https://www.python.org/downloads/" target="_blank"><img src="https://img.shields.io/badge/python-3.6%20|%203.7|%203.8|%203.9|%203.10-brightgreen.svg" alt="Python supported"/></a>
     <a href="https://pypi.org/project/sf-hamilton/" target="_blank"><img src="https://badge.fury.io/py/sf-hamilton.svg" alt="PyPi Version"/></a>
     <a href="https://pepy.tech/project/sf-hamilton" target="_blank"><img src="https://pepy.tech/badge/sf-hamilton" alt="Total Downloads"/></a>
     <br/>

--- a/graph_adapter_tests/h_async/conftest.py
+++ b/graph_adapter_tests/h_async/conftest.py
@@ -1,0 +1,4 @@
+from hamilton import telemetry
+
+# disable telemetry for all tests!
+telemetry.disable_telemetry()

--- a/graph_adapter_tests/h_dask/conftest.py
+++ b/graph_adapter_tests/h_dask/conftest.py
@@ -1,0 +1,4 @@
+from hamilton import telemetry
+
+# disable telemetry for all tests!
+telemetry.disable_telemetry()

--- a/graph_adapter_tests/h_ray/conftest.py
+++ b/graph_adapter_tests/h_ray/conftest.py
@@ -1,0 +1,4 @@
+from hamilton import telemetry
+
+# disable telemetry for all tests!
+telemetry.disable_telemetry()

--- a/graph_adapter_tests/h_spark/conftest.py
+++ b/graph_adapter_tests/h_spark/conftest.py
@@ -1,0 +1,4 @@
+from hamilton import telemetry
+
+# disable telemetry for all tests!
+telemetry.disable_telemetry()

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     # Note that this feature requires pep8 >= v9 and a version of setup tools greater than the
     # default version installed with virtualenv. Make sure to update your tools!


### PR DESCRIPTION
We should be able to support 3.10 without making any changes. This commit adds circleci checks for this.

## Changes
 - No functional changes
 - Adds to circleci config to test 3.10 environment.

## How I tested this
 - ran locally

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
