### PR TITLE
Parses module in more robust way for fn gathering

### DIFF
--- a/hamilton/graph_utils.py
+++ b/hamilton/graph_utils.py
@@ -3,8 +3,8 @@ from types import ModuleType
 from typing import Callable, List, Tuple
 
 
-def is_submodule(child: ModuleType, parent: ModuleType):
-    return parent.__name__ in child.__name__
+def is_submodule(child: str, parent: str):
+    return parent in child
 
 
 def find_functions(function_module: ModuleType) -> List[Tuple[str, Callable]]:
@@ -18,7 +18,7 @@ def find_functions(function_module: ModuleType) -> List[Tuple[str, Callable]]:
         return (
             inspect.isfunction(fn)
             and not fn.__name__.startswith("_")
-            and is_submodule(inspect.getmodule(fn), function_module)
+            and is_submodule(fn.__module__, function_module.__name__)
         )
 
     return [f for f in inspect.getmembers(function_module, predicate=valid_fn)]


### PR DESCRIPTION
inspect.getmodule(fn) depends on the state of sys.modules. This can break if you're doing repeated parsing -- E.G. running it then wiping sys.modules. Instead, we can just ask the function for its module. It's simpler, and won't break.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
