### PR TITLE
Uses the base python graph adapter for type-checking in experimental

### DIFF
--- a/graph_adapter_tests/h_dask/test_h_dask.py
+++ b/graph_adapter_tests/h_dask/test_h_dask.py
@@ -52,12 +52,15 @@ def test_smoke_screen_module(client):
         "pessimistic_net_acquisition_cost",
         "neutral_net_acquisition_cost",
         "optimistic_net_acquisition_cost",
+        "series_with_start_date_end_date",
     ]
     df = dr.execute(
-        inputs={"start_date": "20200101", "end_date": "20220801"}, final_vars=output_columns
+        inputs={"date_range": {"start_date": "20200101", "end_date": "20220801"}},
+        final_vars=output_columns,
     )
     epsilon = 0.00001
     assert abs(df.mean()["raw_acquisition_cost"] - 0.393808) < epsilon
     assert abs(df.mean()["pessimistic_net_acquisition_cost"] - 0.420769) < epsilon
     assert abs(df.mean()["neutral_net_acquisition_cost"] - 0.405582) < epsilon
     assert abs(df.mean()["optimistic_net_acquisition_cost"] - 0.399363) < epsilon
+    assert df["series_with_start_date_end_date"].iloc[0] == "date_20200101_date_20220801"

--- a/graph_adapter_tests/h_dask/test_h_dask.py
+++ b/graph_adapter_tests/h_dask/test_h_dask.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import pytest
 from dask.delayed import delayed
@@ -44,6 +46,7 @@ def test_dask_graph_adapter_simple(client):
     # TODO: do some more asserting?
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
 def test_smoke_screen_module(client):
     config = {"region": "US"}
     dr = driver.Driver(config, smoke_screen_module, adapter=h_dask.DaskGraphAdapter(client))

--- a/graph_adapter_tests/h_ray/test_h_ray.py
+++ b/graph_adapter_tests/h_ray/test_h_ray.py
@@ -54,12 +54,15 @@ def test_smoke_screen_module(init):
         "pessimistic_net_acquisition_cost",
         "neutral_net_acquisition_cost",
         "optimistic_net_acquisition_cost",
+        "series_with_start_date_end_date",
     ]
     df = dr.execute(
-        inputs={"start_date": "20200101", "end_date": "20220801"}, final_vars=output_columns
+        inputs={"date_range": {"start_date": "20200101", "end_date": "20220801"}},
+        final_vars=output_columns,
     )
     epsilon = 0.00001
     assert abs(df.mean()["raw_acquisition_cost"] - 0.393808) < epsilon
     assert abs(df.mean()["pessimistic_net_acquisition_cost"] - 0.420769) < epsilon
     assert abs(df.mean()["neutral_net_acquisition_cost"] - 0.405582) < epsilon
     assert abs(df.mean()["optimistic_net_acquisition_cost"] - 0.399363) < epsilon
+    assert df["series_with_start_date_end_date"].iloc[0] == "date_20200101_date_20220801"

--- a/graph_adapter_tests/h_ray/test_h_ray_workflow.py
+++ b/graph_adapter_tests/h_ray/test_h_ray_workflow.py
@@ -61,12 +61,15 @@ def test_smoke_screen_module(init):
         "pessimistic_net_acquisition_cost",
         "neutral_net_acquisition_cost",
         "optimistic_net_acquisition_cost",
+        "series_with_start_date_end_date",
     ]
     df = dr.execute(
-        inputs={"start_date": "20200101", "end_date": "20220801"}, final_vars=output_columns
+        inputs={"date_range": {"start_date": "20200101", "end_date": "20220801"}},
+        final_vars=output_columns,
     )
     epsilon = 0.00001
     assert abs(df.mean()["raw_acquisition_cost"] - 0.393808) < epsilon
     assert abs(df.mean()["pessimistic_net_acquisition_cost"] - 0.420769) < epsilon
     assert abs(df.mean()["neutral_net_acquisition_cost"] - 0.405582) < epsilon
     assert abs(df.mean()["optimistic_net_acquisition_cost"] - 0.399363) < epsilon
+    assert df["series_with_start_date_end_date"].iloc[0] == "date_20200101_date_20220801"

--- a/graph_adapter_tests/h_spark/test_h_spark.py
+++ b/graph_adapter_tests/h_spark/test_h_spark.py
@@ -70,12 +70,15 @@ def test_smoke_screen_module(spark_session):
         "neutral_net_acquisition_cost",
         "optimistic_net_acquisition_cost",
         "weeks",
+        "series_with_start_date_end_date",
     ]
     df = dr.execute(
-        inputs={"start_date": "20200101", "end_date": "20220801"}, final_vars=output_columns
+        inputs={"date_range": {"start_date": "20200101", "end_date": "20220801"}},
+        final_vars=output_columns,
     )
     epsilon = 0.00001
     assert abs(df.mean()["raw_acquisition_cost"] - 0.393808) < epsilon
     assert abs(df.mean()["pessimistic_net_acquisition_cost"] - 0.420769) < epsilon
     assert abs(df.mean()["neutral_net_acquisition_cost"] - 0.405582) < epsilon
     assert abs(df.mean()["optimistic_net_acquisition_cost"] - 0.399363) < epsilon
+    assert df["series_with_start_date_end_date"].iloc[0] == "date_20200101_date_20220801"

--- a/hamilton/experimental/h_dask.py
+++ b/hamilton/experimental/h_dask.py
@@ -10,6 +10,7 @@ from dask.delayed import Delayed, delayed
 from dask.distributed import Client as DaskClient
 
 from hamilton import base, node
+from hamilton.base import SimplePythonGraphAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class DaskGraphAdapter(base.HamiltonGraphAdapter):
             return True
         elif node_type == np.array and isinstance(input_value, dask.array.Array):
             return True
-        return node_type == typing.Any or isinstance(input_value, node_type)
+        return SimplePythonGraphAdapter.check_input_type(node_type, input_value)
 
     @staticmethod
     def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:

--- a/hamilton/experimental/h_ray.py
+++ b/hamilton/experimental/h_ray.py
@@ -145,7 +145,7 @@ class RayWorkflowGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         # NOTE: the type of a raylet is unknown until they are computed
         if isinstance(input_value, ray._raylet.ObjectRef):
             return True
-        return node_type == typing.Any or isinstance(input_value, node_type)
+        return SimplePythonGraphAdapter.check_input_type(node_type, input_value)
 
     @staticmethod
     def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:

--- a/hamilton/experimental/h_ray.py
+++ b/hamilton/experimental/h_ray.py
@@ -6,6 +6,7 @@ import ray
 from ray import workflow
 
 from hamilton import base, node
+from hamilton.base import SimplePythonGraphAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ class RayGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         # NOTE: the type of a raylet is unknown until they are computed
         if isinstance(input_value, ray._raylet.ObjectRef):
             return True
-        return node_type == typing.Any or isinstance(input_value, node_type)
+        return SimplePythonGraphAdapter.check_input_type(node_type, input_value)
 
     @staticmethod
     def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:

--- a/hamilton/experimental/h_spark.py
+++ b/hamilton/experimental/h_spark.py
@@ -7,6 +7,7 @@ import pyspark.pandas as ps
 from pyspark.sql import dataframe
 
 from hamilton import base, node
+from hamilton.base import SimplePythonGraphAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ class SparkKoalasGraphAdapter(base.HamiltonGraphAdapter, base.ResultMixin):
         elif node_type == np.array and isinstance(input_value, dataframe.DataFrame):
             return True
 
-        return node_type == typing.Any or isinstance(input_value, node_type)
+        return SimplePythonGraphAdapter.check_input_type(node_type, input_value)
 
     @staticmethod
     def check_node_type_equivalence(node_type: typing.Type, input_type: typing.Type) -> bool:

--- a/tests/resources/smoke_screen_module.py
+++ b/tests/resources/smoke_screen_module.py
@@ -39,6 +39,14 @@ from hamilton.function_modifiers import (
 )
 
 
+def start_date(date_range: Dict[str, str]) -> str:
+    return date_range["start_date"]
+
+
+def end_date(date_range: Dict[str, str]) -> str:
+    return date_range["end_date"]
+
+
 def _identity(**kwargs: int) -> int:
     """The API for this is suboptimal but this will serve for testing."""
     return list(kwargs.values())[0]
@@ -114,3 +122,32 @@ def net_signups(
 @tag(final_output="true")
 def acquisition_cost(signups_source: pd.Series, spend: pd.Series) -> pd.Series:
     return spend / signups_source
+
+
+def _prefix_dict_values(prefix: str, dict_to_prefix: Dict[str, str]):
+    """Smoke screen tests to ensure we can work with complex types.
+    Contrived relationship to the theme...
+
+    :param prefix: Some string
+    :param dict_to_prefix: Some dict of string to string
+    :return: Dict b with a concated to keys
+    """
+    return {k: prefix + v for k, v in dict_to_prefix.items()}
+
+
+def date_prefix() -> str:
+    return "date_"
+
+
+@does(_prefix_dict_values, prefix="date_prefix", dict_to_prefix="date_range")
+def prefixed_date_info(date_prefix: str, date_range: Dict[str, str]) -> Dict[str, str]:
+    """Smoke screen tests to ensure we can work with complex types."""
+
+
+def series_with_start_date_end_date(
+    weeks: pd.Series, prefixed_date_info: Dict[str, str]
+) -> pd.Series:
+    """Smoke screen tests to ensure we can work with complex types."""
+    return weeks.apply(
+        lambda x: prefixed_date_info["start_date"] + "_" + prefixed_date_info["end_date"]
+    )

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import hamilton.driver
@@ -32,6 +34,7 @@ def test_data_quality_workflow_fails():
         )
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
 def test_smoke_screen_module():
     config = {"region": "US"}
     dr = hamilton.driver.Driver(config, tests.resources.smoke_screen_module)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -40,12 +40,15 @@ def test_smoke_screen_module():
         "pessimistic_net_acquisition_cost",
         "neutral_net_acquisition_cost",
         "optimistic_net_acquisition_cost",
+        "series_with_start_date_end_date",
     ]
     df = dr.execute(
-        inputs={"start_date": "20200101", "end_date": "20220801"}, final_vars=output_columns
+        inputs={"date_range": {"start_date": "20200101", "end_date": "20220801"}},
+        final_vars=output_columns,
     )
     epsilon = 0.00001
     assert abs(df.mean()["raw_acquisition_cost"] - 0.393808) < epsilon
     assert abs(df.mean()["pessimistic_net_acquisition_cost"] - 0.420769) < epsilon
     assert abs(df.mean()["neutral_net_acquisition_cost"] - 0.405582) < epsilon
     assert abs(df.mean()["optimistic_net_acquisition_cost"] - 0.399363) < epsilon
+    assert df["series_with_start_date_end_date"].iloc[0] == "date_20200101_date_20220801"


### PR DESCRIPTION
graph adapters

Before we were doing it in a custom way -- this broke when a user wanted to use generics. We still don't have amazing generic/type comparison, but this should be able to clean it up.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
