### PR TITLE
Adds ability to pass in a callable to get the function name from for …

### DIFF
--- a/examples/hello_world/my_script.py
+++ b/examples/hello_world/my_script.py
@@ -1,4 +1,4 @@
-import importlib
+# import importlib
 import logging
 import sys
 
@@ -13,21 +13,25 @@ initial_columns = {  # load from actuals or wherever -- this is our initial data
     "spend": pd.Series([10, 10, 20, 40, 40, 50]),
 }
 # we need to tell hamilton where to load function definitions from
-module_name = "my_functions"
-module = importlib.import_module(module_name)
-dr = driver.Driver(initial_columns, module)  # can pass in multiple modules
-# we need to specify what we want in the final dataframe.
+# programmatic code to load modules:
+# module_name = "my_functions"
+# my_functions = importlib.import_module(module_name)
+# or import module(s) directly:
+import my_functions
+
+dr = driver.Driver(initial_columns, my_functions)  # can pass in multiple modules
+# we need to specify what we want in the final dataframe. These can be string names, or function references.
 output_columns = [
     "spend",
     "signups",
-    "avg_3wk_spend",
-    "spend_per_signup",
-    "spend_zero_mean_unit_variance",
+    my_functions.avg_3wk_spend,  # could just pass "avg_3wk_spend" here
+    my_functions.spend_per_signup,  # could just pass "spend_per_signup" here
+    my_functions.spend_zero_mean_unit_variance,  # could just pass "spend_zero_mean_unit_variance" here
 ]
 # let's create the dataframe!
 df = dr.execute(output_columns)
 print(df.to_string())
 
 # To visualize do `pip install sf-hamilton[visualization]` if you want these to work
-# dr.visualize_execution(output_columns, './my_dag.dot', {})
-# dr.display_all_functions('./my_full_dag.dot')
+dr.visualize_execution(output_columns, "./my_dag.dot", {"format": "png"})
+dr.display_all_functions("./my_full_dag.dot", {"format": "png"})

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from types import ModuleType
-from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Collection, Dict, List, Optional, Set, Tuple, Union
 
 import pandas as pd
 
@@ -203,14 +203,14 @@ class Driver(object):
 
     def execute(
         self,
-        final_vars: List[str],
+        final_vars: List[Union[str, Callable]],
         overrides: Dict[str, Any] = None,
         display_graph: bool = False,
         inputs: Dict[str, Any] = None,
     ) -> Any:
         """Executes computation.
 
-        :param final_vars: the final list of variables we want to compute.
+        :param final_vars: the final list of outputs we want to compute.
         :param overrides: values that will override "nodes" in the DAG.
         :param display_graph: DEPRECATED. Whether we want to display the graph being computed.
         :param inputs: Runtime inputs to the DAG.
@@ -226,8 +226,9 @@ class Driver(object):
         start_time = time.time()
         run_successful = True
         error = None
+        _final_vars = self._create_final_vars(final_vars)
         try:
-            outputs = self.raw_execute(final_vars, overrides, display_graph, inputs=inputs)
+            outputs = self.raw_execute(_final_vars, overrides, display_graph, inputs=inputs)
             result = self.adapter.build_result(**outputs)
             return result
         except Exception as e:
@@ -238,8 +239,19 @@ class Driver(object):
         finally:
             duration = time.time() - start_time
             self.capture_execute_telemetry(
-                error, final_vars, inputs, overrides, run_successful, duration
+                error, _final_vars, inputs, overrides, run_successful, duration
             )
+
+    def _create_final_vars(self, final_vars: List[Union[str, Callable]]) -> List[str]:
+        """Creates the final variables list - converting functions names as required.
+
+        :param final_vars:
+        :return: list of strings in the order that final_vars was provided.
+        """
+        _final_vars = [  # take name of function if a function is passed
+            f if isinstance(f, str) else f.__name__ for f in final_vars
+        ]
+        return _final_vars
 
     def capture_execute_telemetry(
         self,
@@ -370,7 +382,8 @@ class Driver(object):
             E.g. dict(graph_attr={'ratio': '1'}) will set the aspect ratio to be equal of the produced image.
             See https://graphviz.org/doc/info/attrs.html for options.
         """
-        nodes, user_nodes = self.graph.get_upstream_nodes(final_vars, inputs)
+        _final_vars = self._create_final_vars(final_vars)
+        nodes, user_nodes = self.graph.get_upstream_nodes(_final_vars, inputs)
         self.validate_inputs(user_nodes, inputs, nodes)
         try:
             self.graph.display(
@@ -390,8 +403,9 @@ class Driver(object):
         :param final_vars: the outputs we want to compute.
         :return: boolean True for cycles, False for no cycles.
         """
+        _final_vars = self._create_final_vars(final_vars)
         # get graph we'd be executing over
-        nodes, user_nodes = self.graph.get_upstream_nodes(final_vars)
+        nodes, user_nodes = self.graph.get_upstream_nodes(_final_vars)
         return self.graph.has_cycles(nodes, user_nodes)
 
     @capture_function_usage

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -251,21 +251,17 @@ class Driver(object):
         """
         _final_vars = []
         errors = []
+        module_set = {_module.__name__ for _module in self.graph_modules}
         for final_var in final_vars:
             if isinstance(final_var, str):
                 _final_vars.append(final_var)
             elif isinstance(final_var, Callable):
-                match = False
-                for _module in self.graph_modules:
-                    if final_var.__module__ == _module.__name__:
-                        match = True
-                        break
-                if match:
+                if final_var.__module__ in module_set:
                     _final_vars.append(final_var.__name__)
                 else:
                     errors.append(
                         f"Function {final_var.__module__}.{final_var.__name__} is a function not in a "
-                        f"module given to the driver. Valid choices are {self.graph_modules}."
+                        f"module given to the driver. Valid choices are {module_set}."
                     )
             else:
                 errors.append(f"Final var {final_var} is not a string or a function.")

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -5,6 +5,7 @@ import pytest
 
 import tests.resources.cyclic_functions
 import tests.resources.tagging
+import tests.resources.test_default_args
 import tests.resources.very_simple_dag
 from hamilton import base
 from hamilton.driver import Driver
@@ -201,6 +202,8 @@ def test_using_callables_to_execute():
     pd.testing.assert_series_equal(results["C"], pd.Series([2], name="C"))
     pd.testing.assert_series_equal(results["B"], pd.Series([1], name="B"))
     pd.testing.assert_series_equal(results["A"], pd.Series([1], name="A"))
+    with pytest.raises(ValueError):
+        dr.execute([tests.resources.cyclic_functions.B])
 
 
 def test__create_final_vars():
@@ -211,3 +214,12 @@ def test__create_final_vars():
     )
     expected = ["C", "B", "A"]
     assert actual == expected
+
+
+def test__create_final_vars_errors():
+    """Tests that we catch functions pointed to in modules that aren't part of the DAG."""
+    dr = Driver({"required": 1}, tests.resources.test_default_args)
+    with pytest.raises(ValueError):
+        dr._create_final_vars(
+            ["C", tests.resources.cyclic_functions.A, tests.resources.cyclic_functions.B]
+        )

--- a/tests/test_hamilton_driver.py
+++ b/tests/test_hamilton_driver.py
@@ -190,3 +190,24 @@ def test__node_is_required_by_anything():
         # D is now in the execution path, but requires defaults_to_zero
         # this should error
         dr.execute(["D"])
+
+
+def test_using_callables_to_execute():
+    """Test that you can pass a function reference and it will work fine."""
+    dr = Driver({"required": 1}, tests.resources.test_default_args)
+    results = dr.execute(
+        [tests.resources.test_default_args.C, tests.resources.test_default_args.B, "A"]
+    )
+    pd.testing.assert_series_equal(results["C"], pd.Series([2], name="C"))
+    pd.testing.assert_series_equal(results["B"], pd.Series([1], name="B"))
+    pd.testing.assert_series_equal(results["A"], pd.Series([1], name="A"))
+
+
+def test__create_final_vars():
+    """Tests that the final vars are created correctly."""
+    dr = Driver({"required": 1}, tests.resources.test_default_args)
+    actual = dr._create_final_vars(
+        ["C", tests.resources.test_default_args.B, tests.resources.test_default_args.A]
+    )
+    expected = ["C", "B", "A"]
+    assert actual == expected


### PR DESCRIPTION
…execute

I found myself wanting to click directly to outputs being created to inspect them. So to short cut that, directly referencing them is a way I can do that and have my IDE jump there when navigating code.

The downside is that this solution doesn't handle functions annotated with decorators that create nodes, e.g. @parameterize*, or @config* . I think that's okay, because it's probably clearer to have a "string" name here to indicate that something is changing/being produced at DAG creation time, and thus a reference to an exact function is likely a misnomer...

Adds unit test for this.

Example usage:
```python
import data_loaders, transforms, model_pipeline
...
dr = driver.Driver(config, data_loaders, transforms, model_pipeline)  
dr.visualize_execution([model_pipeline.kaggle_submission_df], "./kaggle_submission_df.dot.png", {})
kaggle_submission_df: pd.DataFrame = dr.execute([model_pipeline.kaggle_submission_df])
```
The list can be a union of strings or callables. We right now just grab the name of the callable.

## Changes
- execute can now take in a "callable" that we take the name from.
- adds unit test

## How I tested this
 - locally
 - via unit tests

## Notes
 - this will also make it simpler for IDEs to find references and potentially rename things when function names change.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
