### PR TITLE
Decorators now declare the configuration parameters they need

### DIFF
--- a/hamilton/function_modifiers/macros.py
+++ b/hamilton/function_modifiers/macros.py
@@ -226,6 +226,13 @@ class dynamic_transform(base.NodeCreator):
             )
         ]
 
+    def require_config(self) -> List[str]:
+        """Returns the configuration parameters that this model requires
+
+        :return: Just the one config param used by this model
+        """
+        return [self.config_param]
+
 
 class model(dynamic_transform):
     """Model, same as a dynamic transform"""


### PR DESCRIPTION
This allows for inspection/visibility, and will be essential in checkpointing/storage options. We want decorators to declare these upfront, rather than relying on the internals of the decorators to break, enabling clearer error messages for more usable configuration-driven pipelines.

Furthermore, we also allow for some "optional" configuration parameters. These enable us to provide a default. The use-case here is config.when -- which currently defaults to None. Allowing this from the start is not ideal, but it's what we did and users rely on it.

There *is* an out, however. If someone is using the base `@config`, they were able to declare a lambda function, which yields no insight into the parameters required by the function. To bypass this, we pass None out, and the framework knows not to filter the required parameters.

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
